### PR TITLE
Add --grand-total flag

### DIFF
--- a/lib/libyear_bundler/cli.rb
+++ b/lib/libyear_bundler/cli.rb
@@ -5,19 +5,75 @@ require "libyear_bundler/query"
 
 module LibyearBundler
   class CLI
+    OPTIONS = %w(
+      --grand-total
+    ).freeze
+
+    E_BUNDLE_OUTDATED_FAILED = 1
+    E_NO_GEMFILE = 2
+
     def initialize(argv)
-      validate_arguments(argv)
-      @gemfile_path = argv.first
+      @argv = argv
+      @gemfile_path = load_gemfile_path
+      validate_arguments
     end
 
     def run
-      print Report.new(Query.new(@gemfile_path).execute).to_s
+      if @argv.include?("--grand-total")
+        grand_total
+      else
+        print Report.new(query).to_s
+      end
     end
 
     private
 
-    def validate_arguments(argv)
-      # todo
+    def first_arg_is_gemfile?
+      !@argv.first.nil? && ::File.exist?(@argv.first)
+    end
+
+    def fallback_gemfile_exists?
+      # The envvar is set or
+      (!ENV["BUNDLE_GEMFILE"].nil? && ::File.exist?(ENV["BUNDLE_GEMFILE"])) ||
+        # Default to local Gemfile
+        ::File.exist?("Gemfile")
+    end
+
+    def load_gemfile_path
+      if first_arg_is_gemfile?
+        @argv.first
+      elsif fallback_gemfile_exists?
+        '' # `bundle outdated` will default to local Gemfile
+      else
+        $stderr.puts "Gemfile not found"
+        exit
+      end
+    end
+
+    def query
+      Query.new(@gemfile_path).execute
+    end
+
+    def unexpected_options
+      @_unexpected_options ||= begin
+        options = @argv.select { |arg| arg.start_with?("--") }
+        options.each_with_object([]) do |arg, memo|
+          memo << arg unless OPTIONS.include?(arg)
+        end
+      end
+    end
+
+    def validate_arguments
+      unless unexpected_options.empty?
+        puts "Unexpected args: #{unexpected_options.join(", ")}"
+        puts "Allowed args: #{OPTIONS.join(", ")}"
+        exit E_NO_GEMFILE
+      end
+    end
+
+    def grand_total
+      sum_years = query.map { |gem| gem[:libyears] }.inject(0.0, :+)
+      puts sum_years.truncate(1)
     end
   end
 end

--- a/lib/libyear_bundler/query.rb
+++ b/lib/libyear_bundler/query.rb
@@ -55,7 +55,7 @@ module LibyearBundler
         $stderr.puts "stderr: #{stderr}"
         $stderr.puts "stdout: #{stdout}"
         $stderr.puts "Try running `bundle install`."
-        Kernel.exit(1)
+        Kernel.exit(CLI::E_BUNDLE_OUTDATED_FAILED)
       end
       stdout
     end

--- a/libyear-bundler.gemspec
+++ b/libyear-bundler.gemspec
@@ -17,5 +17,6 @@ Gem::Specification.new do |spec|
   spec.bindir = "bin"
   spec.executables = ["libyear-bundler"]
   spec.require_paths = ["lib"]
+  spec.required_ruby_version = ">= 2.1"
   spec.add_dependency "bundler", "~> 1.14"
 end


### PR DESCRIPTION
I'd like to at least start thinking about using libyears as a metric for code health. This PR introduces a command line arg, `--years-only`, which only returns the total libyears that a Gemfile is behind. I also added some validations for command line arguments, but it's not as robust or extensible as it should be and could be the subject of another PR.