### PR TITLE
Add additional metrics

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 Metrics/AbcSize:
-  Max: 20
+  Max: 21
 
 Metrics/LineLength:
   Max: 90

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ Metrics/AbcSize:
   Max: 21
 
 Metrics/LineLength:
-  Max: 90
+  Max: 100
 
 Metrics/MethodLength:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 Metrics/AbcSize:
-  Max: 18
+  Max: 20
 
 Metrics/LineLength:
   Max: 90

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,11 @@
+Metrics/AbcSize:
+  Max: 18
+
+Metrics/LineLength:
+  Max: 90
+
+Metrics/MethodLength:
+  Enabled: false
+
+Style/StringLiterals:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 Metrics/AbcSize:
-  Max: 21
+  Max: 27
 
 Metrics/LineLength:
   Max: 100

--- a/lib/libyear_bundler/calculators/libyear.rb
+++ b/lib/libyear_bundler/calculators/libyear.rb
@@ -1,0 +1,48 @@
+module Calculators
+  class Libyear
+    class << self
+      def calculate(gem)
+        di = release_date(gem[:name], gem[:installed][:version])
+        dn = release_date(gem[:name], gem[:newest][:version])
+        gem[:installed][:date] = di
+        gem[:newest][:date] = dn
+        if di.nil? || dn.nil? || dn <= di
+          # Known issue: Backports and maintenance releases of older minor versions.
+          # Example: json 1.8.6 (2017-01-13) was released *after* 2.0.3 (2017-01-12)
+          years = 0.0
+        else
+          days = (dn - di).to_f
+          years = days / 365.0
+        end
+        years
+      end
+
+      private
+
+      # Known issue: Probably performs a network request every time, unless
+      # there's some kind of caching.
+      def release_date(gem_name, gem_version)
+        dep = nil
+        begin
+          dep = ::Bundler::Dependency.new(gem_name, gem_version)
+        rescue ::Gem::Requirement::BadRequirementError => e
+          $stderr.puts "Could not find release date for: #{gem_name}"
+          $stderr.puts(e)
+          $stderr.puts(
+            "Maybe you used git in your Gemfile, which libyear doesn't support " \
+            "yet. Contributions welcome."
+          )
+          return nil
+        end
+        tuples, _errors = ::Gem::SpecFetcher.fetcher.search_for_dependency(dep)
+        if tuples.empty?
+          $stderr.puts "Could not find release date for: #{gem_name}"
+          return nil
+        end
+        tup, source = tuples.first # Gem::NameTuple
+        spec = source.fetch_spec(tup) # raises Gem::RemoteFetcher::FetchError
+        spec.date.to_date
+      end
+    end
+  end
+end

--- a/lib/libyear_bundler/calculators/libyear.rb
+++ b/lib/libyear_bundler/calculators/libyear.rb
@@ -1,4 +1,6 @@
 module Calculators
+  # A libyear is the difference in time between releases of the newest and
+  # installed versions of the gem in years
   class Libyear
     class << self
       def calculate(gem)

--- a/lib/libyear_bundler/calculators/version_number_delta.rb
+++ b/lib/libyear_bundler/calculators/version_number_delta.rb
@@ -1,6 +1,6 @@
 module Calculators
-  # The version number delta is the differences in major, minor, and patch
-  # versions of the installed and newest releases of the gem
+  # The version number delta is the absolute difference between the highest-
+  # order version number of the installed and newest releases
   class VersionNumberDelta
     class << self
       def calculate(gem)
@@ -15,10 +15,16 @@ module Calculators
         patch_version_delta = version_delta(
           newest_version_tuple.patch, installed_version_tuple.patch
         )
-        [major_version_delta, minor_version_delta, patch_version_delta]
+        highest_order([major_version_delta, minor_version_delta, patch_version_delta])
       end
 
       private
+
+      def highest_order(arr)
+        arr[1] = arr[2] = 0 if arr[0] > 0
+        arr[2] = 0 if arr[1] > 0
+        arr
+      end
 
       def version_delta(newest_version, installed_version)
         delta = newest_version - installed_version

--- a/lib/libyear_bundler/calculators/version_number_delta.rb
+++ b/lib/libyear_bundler/calculators/version_number_delta.rb
@@ -1,12 +1,20 @@
 module Calculators
+  # The version number delta is the differences in major, minor, and patch
+  # versions of the installed and newest releases of the gem
   class VersionNumberDelta
     class << self
       def calculate(gem)
         newest_version_tuple = version_tuple(gem[:newest][:version].split('.'))
         installed_version_tuple = version_tuple(gem[:installed][:version].split('.'))
-        major_version_delta = version_delta(newest_version_tuple.major, installed_version_tuple.major)
-        minor_version_delta = version_delta(newest_version_tuple.minor, installed_version_tuple.minor)
-        patch_version_delta = version_delta(newest_version_tuple.patch, installed_version_tuple.patch)
+        major_version_delta = version_delta(
+          newest_version_tuple.major, installed_version_tuple.major
+        )
+        minor_version_delta = version_delta(
+          newest_version_tuple.minor, installed_version_tuple.minor
+        )
+        patch_version_delta = version_delta(
+          newest_version_tuple.patch, installed_version_tuple.patch
+        )
         [major_version_delta, minor_version_delta, patch_version_delta]
       end
 

--- a/lib/libyear_bundler/calculators/version_number_delta.rb
+++ b/lib/libyear_bundler/calculators/version_number_delta.rb
@@ -1,0 +1,30 @@
+module Calculators
+  class VersionNumberDelta
+    class << self
+      def calculate(gem)
+        newest_version_tuple = version_tuple(gem[:newest][:version].split('.'))
+        installed_version_tuple = version_tuple(gem[:installed][:version].split('.'))
+        major_version_delta = version_delta(newest_version_tuple.major, installed_version_tuple.major)
+        minor_version_delta = version_delta(newest_version_tuple.minor, installed_version_tuple.minor)
+        patch_version_delta = version_delta(newest_version_tuple.patch, installed_version_tuple.patch)
+        [major_version_delta, minor_version_delta, patch_version_delta]
+      end
+
+      private
+
+      def version_delta(newest_version, installed_version)
+        delta = newest_version - installed_version
+        delta < 0 ? 0 : delta
+      end
+
+      def version_tuple(version_array)
+        version_struct = Struct.new(:major, :minor, :patch)
+        version_struct.new(
+          version_array[0].to_i,
+          version_array[1].to_i,
+          version_array[2].to_i
+        )
+      end
+    end
+  end
+end

--- a/lib/libyear_bundler/calculators/version_sequence_delta.rb
+++ b/lib/libyear_bundler/calculators/version_sequence_delta.rb
@@ -3,6 +3,8 @@ require 'uri'
 require 'json'
 
 module Calculators
+  # The version sequence delta is the number of releases between the newest and
+  # installed versions of the gem
   class VersionSequenceDelta
     class << self
       def calculate(gem)

--- a/lib/libyear_bundler/calculators/version_sequence_delta.rb
+++ b/lib/libyear_bundler/calculators/version_sequence_delta.rb
@@ -9,7 +9,6 @@ module Calculators
         uri = URI.parse("https://rubygems.org/api/v1/versions/#{gem[:name]}.json")
         response = Net::HTTP.get_response(uri)
         versions = JSON.parse(response.body).map { |version| version["number"] }
-        require 'pry'
         newest_seq = versions.index(gem[:newest][:version])
         installed_seq = versions.index(gem[:installed][:version])
         installed_seq - newest_seq

--- a/lib/libyear_bundler/calculators/version_sequence_delta.rb
+++ b/lib/libyear_bundler/calculators/version_sequence_delta.rb
@@ -1,0 +1,19 @@
+require 'net/http'
+require 'uri'
+require 'json'
+
+module Calculators
+  class VersionSequenceDelta
+    class << self
+      def calculate(gem)
+        uri = URI.parse("https://rubygems.org/api/v1/versions/#{gem[:name]}.json")
+        response = Net::HTTP.get_response(uri)
+        versions = JSON.parse(response.body).map { |version| version["number"] }
+        require 'pry'
+        newest_seq = versions.index(gem[:newest][:version])
+        installed_seq = versions.index(gem[:installed][:version])
+        installed_seq - newest_seq
+      end
+    end
+  end
+end

--- a/lib/libyear_bundler/cli.rb
+++ b/lib/libyear_bundler/cli.rb
@@ -85,7 +85,9 @@ module LibyearBundler
                     elsif @argv.include?("--versions")
                       versions_grand_total
                     elsif @argv.include?("--all")
-                      "#{libyears_grand_total}\n#{releases_grand_total}\n#{versions_grand_total}"
+                      "#{libyears_grand_total}\n#" \
+                      "{releases_grand_total}\n#" \
+                      "{versions_grand_total}"
                     else
                       libyears_grand_total
                     end

--- a/lib/libyear_bundler/cli.rb
+++ b/lib/libyear_bundler/cli.rb
@@ -56,11 +56,11 @@ module LibyearBundler
     end
 
     def query
-      Query.new(@gemfile_path).execute
+      Query.new(@gemfile_path, @argv).execute
     end
 
     def report
-      @_report ||= Report.new(query, @argv)
+      @_report ||= Report.new(query)
     end
 
     def unexpected_options
@@ -84,16 +84,16 @@ module LibyearBundler
     end
 
     def calculate_grand_total
-      if @argv.include?("--releases")
-        releases_grand_total
-      elsif @argv.include?("--versions")
-        versions_grand_total
-      elsif @argv.include?("--all")
+      if report.to_h.key?(:version_sequence_delta) && report.to_h.key?(:version_number_delta)
         [
           libyears_grand_total,
           releases_grand_total,
           versions_grand_total
         ].join("\n")
+      elsif report.to_h.key?(:version_sequence_delta)
+        releases_grand_total
+      elsif report.to_h.key?(:version_number_delta)
+        versions_grand_total
       else
         libyears_grand_total
       end

--- a/lib/libyear_bundler/cli.rb
+++ b/lib/libyear_bundler/cli.rb
@@ -84,15 +84,15 @@ module LibyearBundler
     end
 
     def calculate_grand_total
-      if report.to_h.key?(:version_sequence_delta) && report.to_h.key?(:version_number_delta)
+      if report.to_h.key?(:sum_seq_delta) && report.to_h.key?(:sum_major_version)
         [
           libyears_grand_total,
           releases_grand_total,
           versions_grand_total
         ].join("\n")
-      elsif report.to_h.key?(:version_sequence_delta)
+      elsif report.to_h.key?(:sum_seq_delta)
         releases_grand_total
-      elsif report.to_h.key?(:version_number_delta)
+      elsif report.to_h.key?(:sum_major_version)
         versions_grand_total
       else
         libyears_grand_total

--- a/lib/libyear_bundler/cli.rb
+++ b/lib/libyear_bundler/cli.rb
@@ -4,10 +4,11 @@ require "libyear_bundler/report"
 require "libyear_bundler/query"
 
 module LibyearBundler
+  # The `libyear-bundler` command line program
   class CLI
-    OPTIONS = %w(
+    OPTIONS = %w[
       --grand-total
-    ).freeze
+    ].freeze
 
     E_BUNDLE_OUTDATED_FAILED = 1
     E_NO_GEMFILE = 2
@@ -64,11 +65,10 @@ module LibyearBundler
     end
 
     def validate_arguments
-      unless unexpected_options.empty?
-        puts "Unexpected args: #{unexpected_options.join(", ")}"
-        puts "Allowed args: #{OPTIONS.join(", ")}"
-        exit E_NO_GEMFILE
-      end
+      return if unexpected_options.empty?
+      puts "Unexpected args: #{unexpected_options.join(', ')}"
+      puts "Allowed args: #{OPTIONS.join(', ')}"
+      exit E_NO_GEMFILE
     end
 
     def grand_total

--- a/lib/libyear_bundler/cli.rb
+++ b/lib/libyear_bundler/cli.rb
@@ -80,19 +80,23 @@ module LibyearBundler
     end
 
     def grand_total
-      grand_total = if @argv.include?("--releases")
-                      releases_grand_total
-                    elsif @argv.include?("--versions")
-                      versions_grand_total
-                    elsif @argv.include?("--all")
-                      "#{libyears_grand_total}\n#" \
-                      "{releases_grand_total}\n#" \
-                      "{versions_grand_total}"
-                    else
-                      libyears_grand_total
-                    end
+      puts calculate_grand_total
+    end
 
-      puts grand_total
+    def calculate_grand_total
+      if @argv.include?("--releases")
+        releases_grand_total
+      elsif @argv.include?("--versions")
+        versions_grand_total
+      elsif @argv.include?("--all")
+        [
+          libyears_grand_total,
+          releases_grand_total,
+          versions_grand_total
+        ].join("\n")
+      else
+        libyears_grand_total
+      end
     end
 
     def libyears_grand_total

--- a/lib/libyear_bundler/cli.rb
+++ b/lib/libyear_bundler/cli.rb
@@ -7,7 +7,10 @@ module LibyearBundler
   # The `libyear-bundler` command line program
   class CLI
     OPTIONS = %w[
+      --all
       --grand-total
+      --releases
+      --versions
     ].freeze
 
     E_BUNDLE_OUTDATED_FAILED = 1
@@ -23,7 +26,7 @@ module LibyearBundler
       if @argv.include?("--grand-total")
         grand_total
       else
-        print Report.new(query).to_s
+        print Report.new(query, @argv).to_s
       end
     end
 

--- a/lib/libyear_bundler/query.rb
+++ b/lib/libyear_bundler/query.rb
@@ -1,6 +1,7 @@
 require "English"
 require "open3"
 require 'libyear_bundler/calculators/libyear'
+require 'libyear_bundler/calculators/version_number_delta'
 
 module LibyearBundler
   # Responsible for getting all the data that goes into the `Report`.
@@ -25,6 +26,7 @@ module LibyearBundler
       end
       gems.each do |gem|
         gem[:libyears] = ::Calculators::Libyear.calculate(gem)
+        gem[:version_number_delta] = ::Calculators::VersionNumberDelta.calculate(gem)
       end
       gems
     end

--- a/lib/libyear_bundler/query.rb
+++ b/lib/libyear_bundler/query.rb
@@ -1,5 +1,6 @@
 require "English"
 require "open3"
+require 'libyear_bundler/calculators/libyear'
 
 module LibyearBundler
   # Responsible for getting all the data that goes into the `Report`.
@@ -23,7 +24,7 @@ module LibyearBundler
         )
       end
       gems.each do |gem|
-        gem[:libyears] = calculate_libyear(gem)
+        gem[:libyears] = ::Calculators::Libyear.calculate(gem)
       end
       gems
     end
@@ -46,47 +47,6 @@ module LibyearBundler
         Kernel.exit(CLI::E_BUNDLE_OUTDATED_FAILED)
       end
       stdout
-    end
-
-    def calculate_libyear(gem)
-      di = release_date(gem[:name], gem[:installed][:version])
-      dn = release_date(gem[:name], gem[:newest][:version])
-      gem[:installed][:date] = di
-      gem[:newest][:date] = dn
-      if di.nil? || dn.nil? || dn <= di
-        # Known issue: Backports and maintenance releases of older minor versions.
-        # Example: json 1.8.6 (2017-01-13) was released *after* 2.0.3 (2017-01-12)
-        years = 0.0
-      else
-        days = (dn - di).to_f
-        years = days / 365.0
-      end
-      years
-    end
-
-    # Known issue: Probably performs a network request every time, unless
-    # there's some kind of caching.
-    def release_date(gem_name, gem_version)
-      dep = nil
-      begin
-        dep = ::Bundler::Dependency.new(gem_name, gem_version)
-      rescue ::Gem::Requirement::BadRequirementError => e
-        $stderr.puts "Could not find release date for: #{gem_name}"
-        $stderr.puts(e)
-        $stderr.puts(
-          "Maybe you used git in your Gemfile, which libyear doesn't support " \
-          "yet. Contributions welcome."
-        )
-        return nil
-      end
-      tuples, _errors = ::Gem::SpecFetcher.fetcher.search_for_dependency(dep)
-      if tuples.empty?
-        $stderr.puts "Could not find release date for: #{gem_name}"
-        return nil
-      end
-      tup, source = tuples.first # Gem::NameTuple
-      spec = source.fetch_spec(tup) # raises Gem::RemoteFetcher::FetchError
-      spec.date.to_date
     end
   end
 end

--- a/lib/libyear_bundler/query.rb
+++ b/lib/libyear_bundler/query.rb
@@ -10,8 +10,9 @@ module LibyearBundler
     # Format of `bundle outdated --parseable` (BOP)
     BOP_FMT = /\A(?<name>[^ ]+) \(newest (?<newest>[^,]+), installed (?<installed>[^,)]+)/
 
-    def initialize(gemfile_path)
+    def initialize(gemfile_path, argv)
       @gemfile_path = gemfile_path
+      @argv = argv
     end
 
     def execute
@@ -26,9 +27,15 @@ module LibyearBundler
         )
       end
       gems.each do |gem|
+        if @argv.include?("--versions") || @argv.include?("--all")
+          gem[:version_number_delta] = ::Calculators::VersionNumberDelta.calculate(gem)
+        end
+
+        if @argv.include?("--releases") || @argv.include?("--all")
+          gem[:version_sequence_delta] = ::Calculators::VersionSequenceDelta.calculate(gem)
+        end
+
         gem[:libyears] = ::Calculators::Libyear.calculate(gem)
-        gem[:version_number_delta] = ::Calculators::VersionNumberDelta.calculate(gem)
-        gem[:version_sequence_delta] = ::Calculators::VersionSequenceDelta.calculate(gem)
       end
       gems
     end

--- a/lib/libyear_bundler/query.rb
+++ b/lib/libyear_bundler/query.rb
@@ -2,6 +2,7 @@ require "English"
 require "open3"
 require 'libyear_bundler/calculators/libyear'
 require 'libyear_bundler/calculators/version_number_delta'
+require 'libyear_bundler/calculators/version_sequence_delta'
 
 module LibyearBundler
   # Responsible for getting all the data that goes into the `Report`.
@@ -27,6 +28,7 @@ module LibyearBundler
       gems.each do |gem|
         gem[:libyears] = ::Calculators::Libyear.calculate(gem)
         gem[:version_number_delta] = ::Calculators::VersionNumberDelta.calculate(gem)
+        gem[:version_sequence_delta] = ::Calculators::VersionSequenceDelta.calculate(gem)
       end
       gems
     end

--- a/lib/libyear_bundler/report.rb
+++ b/lib/libyear_bundler/report.rb
@@ -10,21 +10,27 @@ module LibyearBundler
     def to_s
       sum_years = 0.0
       sum_major_version = sum_minor_version = sum_patch_version = 0
+      sum_seq_delta = 0
       @gems.each do |gem|
         years = gem[:libyears]
         sum_years += years
         sum_major_version += gem[:version_number_delta][0]
         sum_minor_version += gem[:version_number_delta][1]
         sum_patch_version += gem[:version_number_delta][2]
+        sum_seq_delta += gem[:version_sequence_delta]
         puts(
           format(
-            "%30s%15s%15s%15s%15s%10.1f",
+            "%30s%15s%15s%15s%15s%10.1f [%d,%d,%d] %d",
             gem[:name],
             gem[:installed][:version],
             gem[:installed][:date],
             gem[:newest][:version],
             gem[:newest][:date],
-            years
+            years,
+            gem[:version_number_delta][0],
+            gem[:version_number_delta][1],
+            gem[:version_number_delta][2],
+            gem[:version_sequence_delta]
           )
         )
       end
@@ -34,6 +40,7 @@ module LibyearBundler
         sum_minor_version,
         sum_patch_version
       )
+      puts format("Total releases behind: %d", sum_seq_delta)
     end
   end
 end

--- a/lib/libyear_bundler/report.rb
+++ b/lib/libyear_bundler/report.rb
@@ -3,28 +3,36 @@ module LibyearBundler
   # with presentation, nothing else.
   class Report
     # `gems` - Array of hashes.
+    # `flags` - Array of command line arguments
     def initialize(gems, flags)
       @gems = gems
       @flags = flags
     end
 
     def to_s
-      summary = {
-        sum_years: 0.0,
-        sum_major_version: 0,
-        sum_minor_version: 0,
-        sum_patch_version: 0,
-        sum_seq_delta: 0
-      }
-      @gems.each do |gem|
-        summary[:sum_years] += gem[:libyears]
-        summary[:sum_major_version] += gem[:version_number_delta][0]
-        summary[:sum_minor_version] += gem[:version_number_delta][1]
-        summary[:sum_patch_version] += gem[:version_number_delta][2]
-        summary[:sum_seq_delta] += gem[:version_sequence_delta]
-        put_gem_summary(gem)
-      end
-      put_summary(summary)
+      to_h[:gems].each { |gem| put_gem_summary(gem) }
+      put_summary(to_h)
+    end
+
+    def to_h
+      @_to_h ||=
+        begin
+          summary = {
+            gems: @gems,
+            sum_years: 0.0,
+            sum_major_version: 0,
+            sum_minor_version: 0,
+            sum_patch_version: 0,
+            sum_seq_delta: 0
+          }
+          @gems.each_with_object(summary) do |gem, memo|
+            memo[:sum_years] += gem[:libyears]
+            memo[:sum_major_version] += gem[:version_number_delta][0]
+            memo[:sum_minor_version] += gem[:version_number_delta][1]
+            memo[:sum_patch_version] += gem[:version_number_delta][2]
+            memo[:sum_seq_delta] += gem[:version_sequence_delta]
+          end
+        end
     end
 
     private

--- a/lib/libyear_bundler/report.rb
+++ b/lib/libyear_bundler/report.rb
@@ -2,11 +2,12 @@ module LibyearBundler
   # Responsible presenting data from the `Query`. Should only be concerned
   # with presentation, nothing else.
   class Report
+    FMT_RELEASES_COLUMN = "%10d".freeze
+    FMT_VERSIONS_COLUMN = "%15s".freeze
+
     # `gems` - Array of hashes.
-    # `flags` - Array of command line arguments
-    def initialize(gems, flags)
+    def initialize(gems)
       @gems = gems
-      @flags = flags
     end
 
     def to_s
@@ -19,18 +20,24 @@ module LibyearBundler
         begin
           summary = {
             gems: @gems,
-            sum_years: 0.0,
-            sum_major_version: 0,
-            sum_minor_version: 0,
-            sum_patch_version: 0,
-            sum_seq_delta: 0
+            sum_years: 0.0
           }
           @gems.each_with_object(summary) do |gem, memo|
             memo[:sum_years] += gem[:libyears]
-            memo[:sum_major_version] += gem[:version_number_delta][0]
-            memo[:sum_minor_version] += gem[:version_number_delta][1]
-            memo[:sum_patch_version] += gem[:version_number_delta][2]
-            memo[:sum_seq_delta] += gem[:version_sequence_delta]
+
+            if gem.key?(:version_number_delta)
+              memo[:sum_major_version] ||= 0
+              memo[:sum_major_version] += gem[:version_number_delta][0]
+              memo[:sum_minor_version] ||= 0
+              memo[:sum_minor_version] += gem[:version_number_delta][1]
+              memo[:sum_patch_version] ||= 0
+              memo[:sum_patch_version] += gem[:version_number_delta][2]
+            end
+
+            if gem.key?(:version_sequence_delta)
+              memo[:sum_seq_delta] ||= 0
+              memo[:sum_seq_delta] += gem[:version_sequence_delta]
+            end
           end
         end
     end
@@ -40,15 +47,17 @@ module LibyearBundler
     def put_gem_summary(gem)
       meta = meta_gem_summary(gem)
       libyear = format("%10.1f", gem[:libyears])
-      releases = format("%10d", gem[:version_sequence_delta])
-      versions = format("%15s", gem[:version_number_delta])
 
-      if @flags.include?("--releases")
-        puts meta << releases
-      elsif @flags.include?("--versions")
-        puts meta << versions
-      elsif @flags.include?("--all")
+      if gem.key?(:version_sequence_delta) && gem.key?(:version_number_delta)
+        releases = format(FMT_RELEASES_COLUMN, gem[:version_sequence_delta])
+        versions = format(FMT_VERSIONS_COLUMN, gem[:version_number_delta])
         puts meta << libyear << releases << versions
+      elsif gem.key?(:version_sequence_delta)
+        releases = format(FMT_RELEASES_COLUMN, gem[:version_sequence_delta])
+        puts meta << releases
+      elsif gem.key?(:version_number_delta)
+        versions = format(FMT_VERSIONS_COLUMN, gem[:version_number_delta])
+        puts meta << versions
       else
         puts meta << libyear
       end
@@ -83,15 +92,7 @@ module LibyearBundler
     end
 
     def put_summary(summary)
-      if @flags.include?("--versions")
-        put_version_delta_summary(
-          summary[:sum_major_version],
-          summary[:sum_minor_version],
-          summary[:sum_patch_version]
-        )
-      elsif @flags.include?("--releases")
-        put_sum_seq_delta_summary(summary[:sum_seq_delta])
-      elsif @flags.include?("--all")
+      if summary.key?(:sum_years) && summary.key?(:sum_seq_delta) && summary.key?(:sum_major_version)
         put_libyear_summary(summary[:sum_years])
         put_sum_seq_delta_summary(summary[:sum_seq_delta])
         put_version_delta_summary(
@@ -99,6 +100,14 @@ module LibyearBundler
           summary[:sum_minor_version],
           summary[:sum_patch_version]
         )
+      elsif summary.key?(:sum_major_version)
+        put_version_delta_summary(
+          summary[:sum_major_version],
+          summary[:sum_minor_version],
+          summary[:sum_patch_version]
+        )
+      elsif summary.key?(:sum_seq_delta)
+        put_sum_seq_delta_summary(summary[:sum_seq_delta])
       else
         put_libyear_summary(summary[:sum_years])
       end

--- a/lib/libyear_bundler/report.rb
+++ b/lib/libyear_bundler/report.rb
@@ -30,17 +30,10 @@ module LibyearBundler
     private
 
     def put_gem_summary(gem)
-      meta = format(
-        "%30s%15s%15s%15s%15s",
-        gem[:name],
-        gem[:installed][:version],
-        gem[:installed][:date],
-        gem[:newest][:version],
-        gem[:newest][:date]
-      )
+      meta = meta_gem_summary(gem)
       libyear = format("%10.1f", gem[:libyears])
       releases = format("%10d", gem[:version_sequence_delta])
-      versions = format("%15s", gem[:version_number_delta].to_s)
+      versions = format("%15s", gem[:version_number_delta])
 
       if @flags.include?("--releases")
         puts meta << releases
@@ -51,6 +44,17 @@ module LibyearBundler
       else
         puts meta << libyear
       end
+    end
+
+    def meta_gem_summary(gem)
+      format(
+        "%30s%15s%15s%15s%15s",
+        gem[:name],
+        gem[:installed][:version],
+        gem[:installed][:date],
+        gem[:newest][:version],
+        gem[:newest][:date]
+      )
     end
 
     def put_libyear_summary(sum_years)

--- a/lib/libyear_bundler/report.rb
+++ b/lib/libyear_bundler/report.rb
@@ -3,8 +3,9 @@ module LibyearBundler
   # with presentation, nothing else.
   class Report
     # `gems` - Array of hashes.
-    def initialize(gems)
+    def initialize(gems, flags)
       @gems = gems
+      @flags = flags
     end
 
     def to_s
@@ -29,21 +30,27 @@ module LibyearBundler
     private
 
     def put_gem_summary(gem)
-      puts(
-        format(
-          "%30s%15s%15s%15s%15s%10.1f [%d,%d,%d] %d",
-          gem[:name],
-          gem[:installed][:version],
-          gem[:installed][:date],
-          gem[:newest][:version],
-          gem[:newest][:date],
-          gem[:libyears],
-          gem[:version_number_delta][0],
-          gem[:version_number_delta][1],
-          gem[:version_number_delta][2],
-          gem[:version_sequence_delta]
-        )
+      meta = format(
+        "%30s%15s%15s%15s%15s",
+        gem[:name],
+        gem[:installed][:version],
+        gem[:installed][:date],
+        gem[:newest][:version],
+        gem[:newest][:date]
       )
+      libyear = format("%10.1f", gem[:libyears])
+      releases = format("%10d", gem[:version_sequence_delta])
+      versions = format("%15s", gem[:version_number_delta].to_s)
+
+      if @flags.include?("--releases")
+        puts meta << releases
+      elsif @flags.include?("--versions")
+        puts meta << versions
+      elsif @flags.include?("--all")
+        puts meta << libyear << releases << versions
+      else
+        puts meta << libyear
+      end
     end
 
     def put_libyear_summary(sum_years)
@@ -64,13 +71,25 @@ module LibyearBundler
     end
 
     def put_summary(summary)
-      put_libyear_summary(summary[:sum_years])
-      put_version_delta_summary(
-        summary[:sum_major_version],
-        summary[:sum_minor_version],
-        summary[:sum_patch_version]
-      )
-      put_sum_seq_delta_summary(summary[:sum_seq_delta])
+      if @flags.include?("--versions")
+        put_version_delta_summary(
+          summary[:sum_major_version],
+          summary[:sum_minor_version],
+          summary[:sum_patch_version]
+        )
+      elsif @flags.include?("--releases")
+        put_sum_seq_delta_summary(summary[:sum_seq_delta])
+      elsif @flags.include?("--all")
+        put_libyear_summary(summary[:sum_years])
+        put_sum_seq_delta_summary(summary[:sum_seq_delta])
+        put_version_delta_summary(
+          summary[:sum_major_version],
+          summary[:sum_minor_version],
+          summary[:sum_patch_version]
+        )
+      else
+        put_libyear_summary(summary[:sum_years])
+      end
     end
   end
 end

--- a/lib/libyear_bundler/report.rb
+++ b/lib/libyear_bundler/report.rb
@@ -9,9 +9,13 @@ module LibyearBundler
 
     def to_s
       sum_years = 0.0
+      sum_major_version = sum_minor_version = sum_patch_version = 0
       @gems.each do |gem|
         years = gem[:libyears]
         sum_years += years
+        sum_major_version += gem[:version_number_delta][0]
+        sum_minor_version += gem[:version_number_delta][1]
+        sum_patch_version += gem[:version_number_delta][2]
         puts(
           format(
             "%30s%15s%15s%15s%15s%10.1f",
@@ -25,6 +29,11 @@ module LibyearBundler
         )
       end
       puts format("System is %.1f libyears behind", sum_years)
+      puts format("Major, minor, patch versions behind: %d, %d, %d",
+        sum_major_version,
+        sum_minor_version,
+        sum_patch_version
+      )
     end
   end
 end

--- a/lib/libyear_bundler/report.rb
+++ b/lib/libyear_bundler/report.rb
@@ -92,7 +92,7 @@ module LibyearBundler
     end
 
     def put_summary(summary)
-      if summary.key?(:sum_years) && summary.key?(:sum_seq_delta) && summary.key?(:sum_major_version)
+      if summary.key?(:sum_seq_delta) && summary.key?(:sum_major_version)
         put_libyear_summary(summary[:sum_years])
         put_sum_seq_delta_summary(summary[:sum_seq_delta])
         put_version_delta_summary(

--- a/lib/libyear_bundler/report.rb
+++ b/lib/libyear_bundler/report.rb
@@ -10,37 +10,37 @@ module LibyearBundler
     def to_s
       sum_years = 0.0
       sum_major_version = sum_minor_version = sum_patch_version = 0
-      sum_seq_delta = 0
       @gems.each do |gem|
-        years = gem[:libyears]
-        sum_years += years
+        sum_years += gem[:libyears]
         sum_major_version += gem[:version_number_delta][0]
         sum_minor_version += gem[:version_number_delta][1]
         sum_patch_version += gem[:version_number_delta][2]
-        sum_seq_delta += gem[:version_sequence_delta]
-        puts(
-          format(
-            "%30s%15s%15s%15s%15s%10.1f [%d,%d,%d] %d",
-            gem[:name],
-            gem[:installed][:version],
-            gem[:installed][:date],
-            gem[:newest][:version],
-            gem[:newest][:date],
-            years,
-            gem[:version_number_delta][0],
-            gem[:version_number_delta][1],
-            gem[:version_number_delta][2],
-            gem[:version_sequence_delta]
-          )
-        )
+        put_gem_summary(gem)
       end
       puts format("System is %.1f libyears behind", sum_years)
-      puts format("Major, minor, patch versions behind: %d, %d, %d",
+      puts format(
+        "Major, minor, patch versions behind: %d, %d, %d",
         sum_major_version,
         sum_minor_version,
         sum_patch_version
       )
       puts format("Total releases behind: %d", sum_seq_delta)
+    end
+
+    private
+
+    def put_gem_summary(gem)
+      puts(
+        format(
+          "%30s%15s%15s%15s%15s%10.1f",
+          gem[:name],
+          gem[:installed][:version],
+          gem[:installed][:date],
+          gem[:newest][:version],
+          gem[:newest][:date],
+          gem[:libyears]
+        )
+      )
     end
   end
 end

--- a/lib/libyear_bundler/report.rb
+++ b/lib/libyear_bundler/report.rb
@@ -8,23 +8,22 @@ module LibyearBundler
     end
 
     def to_s
-      sum_years = 0.0
-      sum_major_version = sum_minor_version = sum_patch_version = 0
+      summary = {
+        sum_years: 0.0,
+        sum_major_version: 0,
+        sum_minor_version: 0,
+        sum_patch_version: 0,
+        sum_seq_delta: 0
+      }
       @gems.each do |gem|
-        sum_years += gem[:libyears]
-        sum_major_version += gem[:version_number_delta][0]
-        sum_minor_version += gem[:version_number_delta][1]
-        sum_patch_version += gem[:version_number_delta][2]
+        summary[:sum_years] += gem[:libyears]
+        summary[:sum_major_version] += gem[:version_number_delta][0]
+        summary[:sum_minor_version] += gem[:version_number_delta][1]
+        summary[:sum_patch_version] += gem[:version_number_delta][2]
+        summary[:sum_seq_delta] += gem[:version_sequence_delta]
         put_gem_summary(gem)
       end
-      puts format("System is %.1f libyears behind", sum_years)
-      puts format(
-        "Major, minor, patch versions behind: %d, %d, %d",
-        sum_major_version,
-        sum_minor_version,
-        sum_patch_version
-      )
-      puts format("Total releases behind: %d", sum_seq_delta)
+      put_summary(summary)
     end
 
     private
@@ -32,15 +31,46 @@ module LibyearBundler
     def put_gem_summary(gem)
       puts(
         format(
-          "%30s%15s%15s%15s%15s%10.1f",
+          "%30s%15s%15s%15s%15s%10.1f [%d,%d,%d] %d",
           gem[:name],
           gem[:installed][:version],
           gem[:installed][:date],
           gem[:newest][:version],
           gem[:newest][:date],
-          gem[:libyears]
+          gem[:libyears],
+          gem[:version_number_delta][0],
+          gem[:version_number_delta][1],
+          gem[:version_number_delta][2],
+          gem[:version_sequence_delta]
         )
       )
+    end
+
+    def put_libyear_summary(sum_years)
+      puts format("System is %.1f libyears behind", sum_years)
+    end
+
+    def put_version_delta_summary(sum_major_version, sum_minor_version, sum_patch_version)
+      puts format(
+        "Major, minor, patch versions behind: %d, %d, %d",
+        sum_major_version,
+        sum_minor_version,
+        sum_patch_version
+      )
+    end
+
+    def put_sum_seq_delta_summary(sum_seq_delta)
+      puts format("Total releases behind: %d", sum_seq_delta)
+    end
+
+    def put_summary(summary)
+      put_libyear_summary(summary[:sum_years])
+      put_version_delta_summary(
+        summary[:sum_major_version],
+        summary[:sum_minor_version],
+        summary[:sum_patch_version]
+      )
+      put_sum_seq_delta_summary(summary[:sum_seq_delta])
     end
   end
 end

--- a/lib/libyear_bundler/version.rb
+++ b/lib/libyear_bundler/version.rb
@@ -1,3 +1,3 @@
 module LibyearBundler
-  VERSION = "0.3.0"
+  VERSION = "0.3.0".freeze
 end

--- a/libyear-bundler.gemspec
+++ b/libyear-bundler.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'libyear_bundler/version'
@@ -19,4 +20,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.1"
   spec.add_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "rubocop"
 end


### PR DESCRIPTION
The research paper referenced by [libyear.com](https://libyear.com)[[1](https://ericbouwers.github.io/papers/icse15.pdf)] analyzes three metrics to determine "dependency freshness". `libyear` currently supports the authors' _Version Release Date_ metric. This PR adds the remaining two metrics: _Version Sequence Number_ and _Version Number Delta_.

Details:
- Adds flags for each metric, including support for the `--grand-total` flag
- Extracts calculates service objects for each metric
- Adds rubocop as a development dependency and fixes offenses
- Adds `::Report#to_h` for reusability without re-requerying