### PR TITLE
 Use `Gem` model to hold info about gem

### DIFF
--- a/lib/libyear_bundler/calculators/libyear.rb
+++ b/lib/libyear_bundler/calculators/libyear.rb
@@ -1,20 +1,22 @@
-module Calculators
-  # A libyear is the difference in time between releases of the newest and
-  # installed versions of the gem in years
-  class Libyear
-    class << self
-      def calculate(installed_version_release_date, newest_version_release_date)
-        di = installed_version_release_date
-        dn = newest_version_release_date
-        if di.nil? || dn.nil? || dn <= di
-          # Known issue: Backports and maintenance releases of older minor versions.
-          # Example: json 1.8.6 (2017-01-13) was released *after* 2.0.3 (2017-01-12)
-          years = 0.0
-        else
-          days = (dn - di).to_f
-          years = days / 365.0
+module LibyearBundler
+  module Calculators
+    # A libyear is the difference in time between releases of the newest and
+    # installed versions of the gem in years
+    class Libyear
+      class << self
+        def calculate(installed_version_release_date, newest_version_release_date)
+          di = installed_version_release_date
+          dn = newest_version_release_date
+          if di.nil? || dn.nil? || dn <= di
+            # Known issue: Backports and maintenance releases of older minor versions.
+            # Example: json 1.8.6 (2017-01-13) was released *after* 2.0.3 (2017-01-12)
+            years = 0.0
+          else
+            days = (dn - di).to_f
+            years = days / 365.0
+          end
+          years
         end
-        years
       end
     end
   end

--- a/lib/libyear_bundler/calculators/libyear.rb
+++ b/lib/libyear_bundler/calculators/libyear.rb
@@ -3,11 +3,9 @@ module Calculators
   # installed versions of the gem in years
   class Libyear
     class << self
-      def calculate(gem)
-        di = release_date(gem[:name], gem[:installed][:version])
-        dn = release_date(gem[:name], gem[:newest][:version])
-        gem[:installed][:date] = di
-        gem[:newest][:date] = dn
+      def calculate(installed_version_release_date, newest_version_release_date)
+        di = installed_version_release_date
+        dn = newest_version_release_date
         if di.nil? || dn.nil? || dn <= di
           # Known issue: Backports and maintenance releases of older minor versions.
           # Example: json 1.8.6 (2017-01-13) was released *after* 2.0.3 (2017-01-12)
@@ -17,33 +15,6 @@ module Calculators
           years = days / 365.0
         end
         years
-      end
-
-      private
-
-      # Known issue: Probably performs a network request every time, unless
-      # there's some kind of caching.
-      def release_date(gem_name, gem_version)
-        dep = nil
-        begin
-          dep = ::Bundler::Dependency.new(gem_name, gem_version)
-        rescue ::Gem::Requirement::BadRequirementError => e
-          $stderr.puts "Could not find release date for: #{gem_name}"
-          $stderr.puts(e)
-          $stderr.puts(
-            "Maybe you used git in your Gemfile, which libyear doesn't support " \
-            "yet. Contributions welcome."
-          )
-          return nil
-        end
-        tuples, _errors = ::Gem::SpecFetcher.fetcher.search_for_dependency(dep)
-        if tuples.empty?
-          $stderr.puts "Could not find release date for: #{gem_name}"
-          return nil
-        end
-        tup, source = tuples.first # Gem::NameTuple
-        spec = source.fetch_spec(tup) # raises Gem::RemoteFetcher::FetchError
-        spec.date.to_date
       end
     end
   end

--- a/lib/libyear_bundler/calculators/version_number_delta.rb
+++ b/lib/libyear_bundler/calculators/version_number_delta.rb
@@ -5,8 +5,8 @@ module LibyearBundler
     class VersionNumberDelta
       class << self
         def calculate(installed_version, newest_version)
-          installed_version_tuple = version_tuple(installed_version.split('.'))
-          newest_version_tuple = version_tuple(newest_version.split('.'))
+          installed_version_tuple = version_tuple(installed_version.to_s.split('.'))
+          newest_version_tuple = version_tuple(newest_version.to_s.split('.'))
           major_version_delta = version_delta(
             newest_version_tuple.major, installed_version_tuple.major
           )

--- a/lib/libyear_bundler/calculators/version_number_delta.rb
+++ b/lib/libyear_bundler/calculators/version_number_delta.rb
@@ -1,43 +1,45 @@
-module Calculators
-  # The version number delta is the absolute difference between the highest-
-  # order version number of the installed and newest releases
-  class VersionNumberDelta
-    class << self
-      def calculate(installed_version, newest_version)
-        installed_version_tuple = version_tuple(installed_version.split('.'))
-        newest_version_tuple = version_tuple(newest_version.split('.'))
-        major_version_delta = version_delta(
-          newest_version_tuple.major, installed_version_tuple.major
-        )
-        minor_version_delta = version_delta(
-          newest_version_tuple.minor, installed_version_tuple.minor
-        )
-        patch_version_delta = version_delta(
-          newest_version_tuple.patch, installed_version_tuple.patch
-        )
-        highest_order([major_version_delta, minor_version_delta, patch_version_delta])
-      end
+module LibyearBundler
+  module Calculators
+    # The version number delta is the absolute difference between the highest-
+    # order version number of the installed and newest releases
+    class VersionNumberDelta
+      class << self
+        def calculate(installed_version, newest_version)
+          installed_version_tuple = version_tuple(installed_version.split('.'))
+          newest_version_tuple = version_tuple(newest_version.split('.'))
+          major_version_delta = version_delta(
+            newest_version_tuple.major, installed_version_tuple.major
+          )
+          minor_version_delta = version_delta(
+            newest_version_tuple.minor, installed_version_tuple.minor
+          )
+          patch_version_delta = version_delta(
+            newest_version_tuple.patch, installed_version_tuple.patch
+          )
+          highest_order([major_version_delta, minor_version_delta, patch_version_delta])
+        end
 
-      private
+        private
 
-      def highest_order(arr)
-        arr[1] = arr[2] = 0 if arr[0] > 0
-        arr[2] = 0 if arr[1] > 0
-        arr
-      end
+        def highest_order(arr)
+          arr[1] = arr[2] = 0 if arr[0] > 0
+          arr[2] = 0 if arr[1] > 0
+          arr
+        end
 
-      def version_delta(newest_version, installed_version)
-        delta = newest_version - installed_version
-        delta < 0 ? 0 : delta
-      end
+        def version_delta(newest_version, installed_version)
+          delta = newest_version - installed_version
+          delta < 0 ? 0 : delta
+        end
 
-      def version_tuple(version_array)
-        version_struct = Struct.new(:major, :minor, :patch)
-        version_struct.new(
-          version_array[0].to_i,
-          version_array[1].to_i,
-          version_array[2].to_i
-        )
+        def version_tuple(version_array)
+          version_struct = Struct.new(:major, :minor, :patch)
+          version_struct.new(
+            version_array[0].to_i,
+            version_array[1].to_i,
+            version_array[2].to_i
+          )
+        end
       end
     end
   end

--- a/lib/libyear_bundler/calculators/version_sequence_delta.rb
+++ b/lib/libyear_bundler/calculators/version_sequence_delta.rb
@@ -1,27 +1,10 @@
-require 'net/http'
-require 'uri'
-require 'json'
-
 module Calculators
   # The version sequence delta is the number of releases between the newest and
   # installed versions of the gem
   class VersionSequenceDelta
     class << self
-      def calculate(gem_name, installed_version, newest_version)
-        # Versions are returned ordered by version number, descending
-        versions =  gem_version_details(gem_name).map { |version| version["number"] }
-        installed_seq = versions.index(installed_version)
-        newest_seq = versions.index(newest_version)
-        installed_seq - newest_seq
-      end
-
-      private
-
-      # docs: http://guides.rubygems.org/rubygems-org-api/#gem-version-methods
-      def gem_version_details(gem_name)
-        uri = URI.parse("https://rubygems.org/api/v1/versions/#{gem_name}.json")
-        response = Net::HTTP.get_response(uri)
-        JSON.parse(response.body)
+      def calculate(installed_seq_index, newest_seq_index)
+        installed_seq_index - newest_seq_index
       end
     end
   end

--- a/lib/libyear_bundler/calculators/version_sequence_delta.rb
+++ b/lib/libyear_bundler/calculators/version_sequence_delta.rb
@@ -1,10 +1,12 @@
-module Calculators
-  # The version sequence delta is the number of releases between the newest and
-  # installed versions of the gem
-  class VersionSequenceDelta
-    class << self
-      def calculate(installed_seq_index, newest_seq_index)
-        installed_seq_index - newest_seq_index
+module LibyearBundler
+  module Calculators
+    # The version sequence delta is the number of releases between the newest and
+    # installed versions of the gem
+    class VersionSequenceDelta
+      class << self
+        def calculate(installed_seq_index, newest_seq_index)
+          installed_seq_index - newest_seq_index
+        end
       end
     end
   end

--- a/lib/libyear_bundler/cli.rb
+++ b/lib/libyear_bundler/cli.rb
@@ -56,11 +56,11 @@ module LibyearBundler
     end
 
     def query
-      Query.new(@gemfile_path, @argv).execute
+      Query.new(@gemfile_path).execute
     end
 
     def report
-      @_report ||= Report.new(query)
+      @_report ||= Report.new(query, @argv)
     end
 
     def unexpected_options

--- a/lib/libyear_bundler/models/gem.rb
+++ b/lib/libyear_bundler/models/gem.rb
@@ -52,7 +52,7 @@ module LibyearBundler
       end
 
       def version_sequence_delta
-        ::LibyearBundler::Calculators::VersionSequenceDelta(
+        ::LibyearBundler::Calculators::VersionSequenceDelta.calculate(
           installed_version_sequence_index,
           newest_version_sequence_index
         )

--- a/lib/libyear_bundler/models/gem.rb
+++ b/lib/libyear_bundler/models/gem.rb
@@ -5,10 +5,6 @@ require 'json'
 module LibyearBundler
   module Models
     class Gem
-      attr_accessor :libyears,
-        :version_number_delta, # returns [major, minor, patch]
-        :version_sequence_delta
-
       def initialize(match)
         @match = match
       end
@@ -25,6 +21,13 @@ module LibyearBundler
         versions_sequence.index(installed_version.to_s)
       end
 
+      def libyears
+        ::LibyearBundler::Calculators::Libyear.calculate(
+          installed_version_release_date,
+          newest_version_release_date
+        )
+      end
+
       def name
         @match['name']
       end
@@ -39,6 +42,20 @@ module LibyearBundler
 
       def newest_version_release_date
         release_date(name, newest_version)
+      end
+
+      def version_number_delta
+        ::LibyearBundler::Calculators::VersionNumberDelta.calculate(
+          installed_version,
+          newest_version
+        )
+      end
+
+      def version_sequence_delta
+        ::LibyearBundler::Calculators::VersionSequenceDelta(
+          installed_version_sequence_index,
+          newest_version_sequence_index
+        )
       end
 
       private

--- a/lib/libyear_bundler/models/gem.rb
+++ b/lib/libyear_bundler/models/gem.rb
@@ -5,12 +5,14 @@ require 'json'
 module LibyearBundler
   module Models
     class Gem
-      def initialize(match)
-        @match = match
+      def initialize(name, installed_version, newest_version)
+        @name = name
+        @installed_version = installed_version
+        @newest_version = newest_version
       end
 
       def installed_version
-        ::Gem::Version.new(@match['installed'])
+        ::Gem::Version.new(@installed_version)
       end
 
       def installed_version_release_date
@@ -29,11 +31,11 @@ module LibyearBundler
       end
 
       def name
-        @match['name']
+        @name
       end
 
       def newest_version
-        ::Gem::Version.new(@match['newest'])
+        ::Gem::Version.new(@newest_version)
       end
 
       def newest_version_sequence_index

--- a/lib/libyear_bundler/models/gem.rb
+++ b/lib/libyear_bundler/models/gem.rb
@@ -1,0 +1,81 @@
+require 'net/http'
+require 'uri'
+require 'json'
+
+module Models
+  class Gem
+    attr_accessor :libyears,
+      :version_number_delta, # returns [major, minor, patch]
+      :version_sequence_delta
+
+    def initialize(match)
+      @match = match
+    end
+
+    def installed_version
+      ::Gem::Version.new(@match['installed'])
+    end
+
+    def installed_version_release_date
+      release_date(name, installed_version)
+    end
+
+    def installed_version_sequence_index
+      versions_sequence.index(installed_version.to_s)
+    end
+
+    def name
+      @match['name']
+    end
+
+    def newest_version
+      ::Gem::Version.new(@match['newest'])
+    end
+
+    def newest_version_sequence_index
+      versions_sequence.index(newest_version.to_s)
+    end
+
+    def newest_version_release_date
+      release_date(name, newest_version)
+    end
+
+    private
+
+    # docs: http://guides.rubygems.org/rubygems-org-api/#gem-version-methods
+    # Versions are returned ordered by version number, descending
+    def versions_sequence
+      @_versions_sequence ||= begin
+        uri = URI.parse("https://rubygems.org/api/v1/versions/#{name}.json")
+        response = Net::HTTP.get_response(uri)
+        parsed_response = JSON.parse(response.body)
+        parsed_response.map { |version| version['number'] }
+      end
+    end
+
+    # Known issue: Probably performs a network request every time, unless
+    # there's some kind of caching.
+    def release_date(gem_name, gem_version)
+      dep = nil
+      begin
+        dep = ::Bundler::Dependency.new(gem_name, gem_version)
+      rescue ::Gem::Requirement::BadRequirementError => e
+        $stderr.puts "Could not find release date for: #{gem_name}"
+        $stderr.puts(e)
+        $stderr.puts(
+          "Maybe you used git in your Gemfile, which libyear doesn't support " \
+            "yet. Contributions welcome."
+        )
+        return nil
+      end
+      tuples, _errors = ::Gem::SpecFetcher.fetcher.search_for_dependency(dep)
+      if tuples.empty?
+        $stderr.puts "Could not find release date for: #{gem_name}"
+        return nil
+      end
+      tup, source = tuples.first # Gem::NameTuple
+      spec = source.fetch_spec(tup) # raises Gem::RemoteFetcher::FetchError
+      spec.date.to_date
+    end
+  end
+end

--- a/lib/libyear_bundler/models/gem.rb
+++ b/lib/libyear_bundler/models/gem.rb
@@ -2,80 +2,82 @@ require 'net/http'
 require 'uri'
 require 'json'
 
-module Models
-  class Gem
-    attr_accessor :libyears,
-      :version_number_delta, # returns [major, minor, patch]
-      :version_sequence_delta
+module LibyearBundler
+  module Models
+    class Gem
+      attr_accessor :libyears,
+        :version_number_delta, # returns [major, minor, patch]
+        :version_sequence_delta
 
-    def initialize(match)
-      @match = match
-    end
-
-    def installed_version
-      ::Gem::Version.new(@match['installed'])
-    end
-
-    def installed_version_release_date
-      release_date(name, installed_version)
-    end
-
-    def installed_version_sequence_index
-      versions_sequence.index(installed_version.to_s)
-    end
-
-    def name
-      @match['name']
-    end
-
-    def newest_version
-      ::Gem::Version.new(@match['newest'])
-    end
-
-    def newest_version_sequence_index
-      versions_sequence.index(newest_version.to_s)
-    end
-
-    def newest_version_release_date
-      release_date(name, newest_version)
-    end
-
-    private
-
-    # docs: http://guides.rubygems.org/rubygems-org-api/#gem-version-methods
-    # Versions are returned ordered by version number, descending
-    def versions_sequence
-      @_versions_sequence ||= begin
-        uri = URI.parse("https://rubygems.org/api/v1/versions/#{name}.json")
-        response = Net::HTTP.get_response(uri)
-        parsed_response = JSON.parse(response.body)
-        parsed_response.map { |version| version['number'] }
+      def initialize(match)
+        @match = match
       end
-    end
 
-    # Known issue: Probably performs a network request every time, unless
-    # there's some kind of caching.
-    def release_date(gem_name, gem_version)
-      dep = nil
-      begin
-        dep = ::Bundler::Dependency.new(gem_name, gem_version)
-      rescue ::Gem::Requirement::BadRequirementError => e
-        $stderr.puts "Could not find release date for: #{gem_name}"
-        $stderr.puts(e)
-        $stderr.puts(
-          "Maybe you used git in your Gemfile, which libyear doesn't support " \
-            "yet. Contributions welcome."
-        )
-        return nil
+      def installed_version
+        ::Gem::Version.new(@match['installed'])
       end
-      tuples, _errors = ::Gem::SpecFetcher.fetcher.search_for_dependency(dep)
-      if tuples.empty?
-        $stderr.puts "Could not find release date for: #{gem_name}"
-        return nil
+
+      def installed_version_release_date
+        release_date(name, installed_version)
       end
-      tup, source = tuples.first # Gem::NameTuple
-      spec = source.fetch_spec(tup) # raises Gem::RemoteFetcher::FetchError
-      spec.date.to_date
+
+      def installed_version_sequence_index
+        versions_sequence.index(installed_version.to_s)
+      end
+
+      def name
+        @match['name']
+      end
+
+      def newest_version
+        ::Gem::Version.new(@match['newest'])
+      end
+
+      def newest_version_sequence_index
+        versions_sequence.index(newest_version.to_s)
+      end
+
+      def newest_version_release_date
+        release_date(name, newest_version)
+      end
+
+      private
+
+      # docs: http://guides.rubygems.org/rubygems-org-api/#gem-version-methods
+      # Versions are returned ordered by version number, descending
+      def versions_sequence
+        @_versions_sequence ||= begin
+          uri = URI.parse("https://rubygems.org/api/v1/versions/#{name}.json")
+          response = Net::HTTP.get_response(uri)
+          parsed_response = JSON.parse(response.body)
+          parsed_response.map { |version| version['number'] }
+        end
+      end
+
+      # Known issue: Probably performs a network request every time, unless
+      # there's some kind of caching.
+      def release_date(gem_name, gem_version)
+        dep = nil
+        begin
+          dep = ::Bundler::Dependency.new(gem_name, gem_version)
+        rescue ::Gem::Requirement::BadRequirementError => e
+          $stderr.puts "Could not find release date for: #{gem_name}"
+          $stderr.puts(e)
+          $stderr.puts(
+            "Maybe you used git in your Gemfile, which libyear doesn't support " \
+              "yet. Contributions welcome."
+          )
+          return nil
+        end
+        tuples, _errors = ::Gem::SpecFetcher.fetcher.search_for_dependency(dep)
+        if tuples.empty?
+          $stderr.puts "Could not find release date for: #{gem_name}"
+          return nil
+        end
+        tup, source = tuples.first # Gem::NameTuple
+        spec = source.fetch_spec(tup) # raises Gem::RemoteFetcher::FetchError
+        spec.date.to_date
+      end
     end
   end
 end

--- a/lib/libyear_bundler/query.rb
+++ b/lib/libyear_bundler/query.rb
@@ -20,7 +20,12 @@ module LibyearBundler
       bundle_outdated.lines.each do |line|
         match = BOP_FMT.match(line)
         next if match.nil?
-        gems.push(::Models::Gem.new(match))
+        gem = ::LibyearBundler::Models::Gem.new(
+          match['name'],
+          match['installed_version'],
+          match['newest_version']
+        )
+        gems.push(gem)
       end
       gems.each do |gem|
         if @argv.include?("--versions") || @argv.include?("--all")

--- a/lib/libyear_bundler/query.rb
+++ b/lib/libyear_bundler/query.rb
@@ -11,9 +11,8 @@ module LibyearBundler
     # Format of `bundle outdated --parseable` (BOP)
     BOP_FMT = /\A(?<name>[^ ]+) \(newest (?<newest>[^,]+), installed (?<installed>[^,)]+)/
 
-    def initialize(gemfile_path, argv)
+    def initialize(gemfile_path)
       @gemfile_path = gemfile_path
-      @argv = argv
     end
 
     def execute

--- a/lib/libyear_bundler/report.rb
+++ b/lib/libyear_bundler/report.rb
@@ -23,20 +23,20 @@ module LibyearBundler
             sum_years: 0.0
           }
           @gems.each_with_object(summary) do |gem, memo|
-            memo[:sum_years] += gem[:libyears]
+            memo[:sum_years] += gem.libyears
 
-            if gem.key?(:version_number_delta)
+            if !gem.version_number_delta.nil?
               memo[:sum_major_version] ||= 0
-              memo[:sum_major_version] += gem[:version_number_delta][0]
+              memo[:sum_major_version] += gem.version_number_delta[0]
               memo[:sum_minor_version] ||= 0
-              memo[:sum_minor_version] += gem[:version_number_delta][1]
+              memo[:sum_minor_version] += gem.version_number_delta[1]
               memo[:sum_patch_version] ||= 0
-              memo[:sum_patch_version] += gem[:version_number_delta][2]
+              memo[:sum_patch_version] += gem.version_number_delta[2]
             end
 
-            if gem.key?(:version_sequence_delta)
+            if !gem.version_sequence_delta.nil?
               memo[:sum_seq_delta] ||= 0
-              memo[:sum_seq_delta] += gem[:version_sequence_delta]
+              memo[:sum_seq_delta] += gem.version_sequence_delta
             end
           end
         end
@@ -46,17 +46,17 @@ module LibyearBundler
 
     def put_gem_summary(gem)
       meta = meta_gem_summary(gem)
-      libyear = format("%10.1f", gem[:libyears])
+      libyear = format("%10.1f", gem.libyears)
 
-      if gem.key?(:version_sequence_delta) && gem.key?(:version_number_delta)
-        releases = format(FMT_RELEASES_COLUMN, gem[:version_sequence_delta])
-        versions = format(FMT_VERSIONS_COLUMN, gem[:version_number_delta])
+      if !gem.version_sequence_delta.nil? && !gem.version_number_delta.nil?
+        releases = format(FMT_RELEASES_COLUMN, gem.version_sequence_delta)
+        versions = format(FMT_VERSIONS_COLUMN, gem.version_number_delta)
         puts meta << libyear << releases << versions
-      elsif gem.key?(:version_sequence_delta)
-        releases = format(FMT_RELEASES_COLUMN, gem[:version_sequence_delta])
+      elsif !gem.version_sequence_delta.nil?
+        releases = format(FMT_RELEASES_COLUMN, gem.version_sequence_delta)
         puts meta << releases
-      elsif gem.key?(:version_number_delta)
-        versions = format(FMT_VERSIONS_COLUMN, gem[:version_number_delta])
+      elsif !gem.version_number_delta.nil?
+        versions = format(FMT_VERSIONS_COLUMN, gem.version_number_delta)
         puts meta << versions
       else
         puts meta << libyear
@@ -66,11 +66,11 @@ module LibyearBundler
     def meta_gem_summary(gem)
       format(
         "%30s%15s%15s%15s%15s",
-        gem[:name],
-        gem[:installed][:version],
-        gem[:installed][:date],
-        gem[:newest][:version],
-        gem[:newest][:date]
+        gem.name,
+        gem.installed_version.to_s,
+        gem.installed_version_release_date,
+        gem.newest_version.to_s,
+        gem.newest_version_release_date
       )
     end
 

--- a/lib/libyear_bundler/report.rb
+++ b/lib/libyear_bundler/report.rb
@@ -6,8 +6,9 @@ module LibyearBundler
     FMT_VERSIONS_COLUMN = "%15s".freeze
 
     # `gems` - Array of hashes.
-    def initialize(gems)
+    def initialize(gems, argv)
       @gems = gems
+      @argv = argv
     end
 
     def to_s
@@ -25,7 +26,7 @@ module LibyearBundler
           @gems.each_with_object(summary) do |gem, memo|
             memo[:sum_years] += gem.libyears
 
-            if !gem.version_number_delta.nil?
+            if @argv.include?("--versions") || @argv.include?("--all")
               memo[:sum_major_version] ||= 0
               memo[:sum_major_version] += gem.version_number_delta[0]
               memo[:sum_minor_version] ||= 0
@@ -34,7 +35,7 @@ module LibyearBundler
               memo[:sum_patch_version] += gem.version_number_delta[2]
             end
 
-            if !gem.version_sequence_delta.nil?
+            if @argv.include?("--releases") || @argv.include?("--all")
               memo[:sum_seq_delta] ||= 0
               memo[:sum_seq_delta] += gem.version_sequence_delta
             end
@@ -48,14 +49,14 @@ module LibyearBundler
       meta = meta_gem_summary(gem)
       libyear = format("%10.1f", gem.libyears)
 
-      if !gem.version_sequence_delta.nil? && !gem.version_number_delta.nil?
+      if (@argv.include?("--releases") && @argv.include?("--versions")) || @argv.include?("--all")
         releases = format(FMT_RELEASES_COLUMN, gem.version_sequence_delta)
         versions = format(FMT_VERSIONS_COLUMN, gem.version_number_delta)
         puts meta << libyear << releases << versions
-      elsif !gem.version_sequence_delta.nil?
+      elsif @argv.include?("--releases")
         releases = format(FMT_RELEASES_COLUMN, gem.version_sequence_delta)
         puts meta << releases
-      elsif !gem.version_number_delta.nil?
+      elsif @argv.include?("--versions")
         versions = format(FMT_VERSIONS_COLUMN, gem.version_number_delta)
         puts meta << versions
       else

--- a/spec/calculators/libyear_spec.rb
+++ b/spec/calculators/libyear_spec.rb
@@ -1,15 +1,17 @@
 require 'spec_helper'
 require 'date'
 
-module Calculators
-  RSpec.describe Libyear do
-    describe '#calculate' do
-      it 'returns the time difference between gem releases in years' do
-        installed_date = Date.new(2016, 1, 1)
-        newest_date = Date.new(2017, 1, 1)
+module LibyearBundler
+  module Calculators
+    RSpec.describe Libyear do
+      describe '#calculate' do
+        it 'returns the time difference between gem releases in years' do
+          installed_date = Date.new(2016, 1, 1)
+          newest_date = Date.new(2017, 1, 1)
 
-        expect(described_class.calculate(installed_date, newest_date)).
-          to be_within(0.01).of(1.00)
+          expect(described_class.calculate(installed_date, newest_date)).
+            to be_within(0.01).of(1.00)
+        end
       end
     end
   end

--- a/spec/calculators/libyear_spec.rb
+++ b/spec/calculators/libyear_spec.rb
@@ -7,24 +7,9 @@ module Calculators
       it 'returns the time difference between gem releases in years' do
         installed_date = Date.new(2016, 1, 1)
         newest_date = Date.new(2017, 1, 1)
-        gem_name = 'mock_gem'
 
-        allow(described_class)
-          .to receive(:release_date)
-          .with(gem_name, '1.0')
-          .and_return(installed_date)
-        allow(described_class)
-          .to receive(:release_date)
-          .with(gem_name, '2.0')
-          .and_return(newest_date)
-
-        gem = {
-          name: gem_name,
-          installed: { version: '1.0', date: installed_date },
-          newest: { version: '2.0', date: newest_date }
-        }
-
-        expect(described_class.calculate(gem)).to be_within(0.01).of(1.00)
+        expect(described_class.calculate(installed_date, newest_date)).
+          to be_within(0.01).of(1.00)
       end
     end
   end

--- a/spec/calculators/version_number_delta_spec.rb
+++ b/spec/calculators/version_number_delta_spec.rb
@@ -1,53 +1,55 @@
 require 'spec_helper'
 
-module Calculators
-  RSpec.describe VersionNumberDelta do
-    describe '#calculate' do
-      it 'returns the difference in version numbers between releases' do
-        installed_version = '1.0.0'
-        newest_version = '2.0.0'
-
-        expect(described_class.calculate(installed_version, newest_version))
-          .to eq([1, 0, 0])
-      end
-
-      context 'major, minor, and patch numbers are different' do
-        it 'returns the major version difference' do
-          installed_version = '1.1.1'
-          newest_version = '2.2.2'
+module LibyearBundler
+  module Calculators
+    RSpec.describe VersionNumberDelta do
+      describe '#calculate' do
+        it 'returns the difference in version numbers between releases' do
+          installed_version = '1.0.0'
+          newest_version = '2.0.0'
 
           expect(described_class.calculate(installed_version, newest_version))
             .to eq([1, 0, 0])
         end
-      end
 
-      context 'minor and patch numbers are different' do
-        it 'returns the minor version difference' do
-          installed_version = '1.1.1'
-          newest_version = '1.2.2'
+        context 'major, minor, and patch numbers are different' do
+          it 'returns the major version difference' do
+            installed_version = '1.1.1'
+            newest_version = '2.2.2'
 
-          expect(described_class.calculate(installed_version, newest_version))
-            .to eq([0, 1, 0])
+            expect(described_class.calculate(installed_version, newest_version))
+              .to eq([1, 0, 0])
+          end
         end
-      end
 
-      context 'patch numbers are different' do
-        it 'returns the patch version difference' do
-          installed_version = '1.1.1'
-          newest_version = '1.1.2'
+        context 'minor and patch numbers are different' do
+          it 'returns the minor version difference' do
+            installed_version = '1.1.1'
+            newest_version = '1.2.2'
 
-          expect(described_class.calculate(installed_version, newest_version))
-            .to eq([0, 0, 1])
+            expect(described_class.calculate(installed_version, newest_version))
+              .to eq([0, 1, 0])
+          end
         end
-      end
 
-      context 'new minor and patch version numbers are lower' do
-        it 'returns the major version difference' do
-          installed_version = '1.2.2'
-          newest_version = '2.1.1'
+        context 'patch numbers are different' do
+          it 'returns the patch version difference' do
+            installed_version = '1.1.1'
+            newest_version = '1.1.2'
 
-          expect(described_class.calculate(installed_version, newest_version))
-            .to eq([1, 0, 0])
+            expect(described_class.calculate(installed_version, newest_version))
+              .to eq([0, 0, 1])
+          end
+        end
+
+        context 'new minor and patch version numbers are lower' do
+          it 'returns the major version difference' do
+            installed_version = '1.2.2'
+            newest_version = '2.1.1'
+
+            expect(described_class.calculate(installed_version, newest_version))
+              .to eq([1, 0, 0])
+          end
         end
       end
     end

--- a/spec/calculators/version_sequence_delta_spec.rb
+++ b/spec/calculators/version_sequence_delta_spec.rb
@@ -4,25 +4,12 @@ module Calculators
   RSpec.describe VersionSequenceDelta do
     describe '#calculate' do
       it 'returns the number of releases between the newest and installed versions' do
-        gem_name = 'mock_gem'
-        installed_version = '1.0.0'
-        newest_version = '3.0.0'
-
-        allow(described_class)
-          .to receive(:gem_version_details)
-          .with(gem_name)
-          .and_return(
-            [
-              { 'number' => newest_version },
-              { 'number' => '2.0.0' },
-              { 'number' => installed_version }
-            ]
-          )
+        installed_version_sequence_index = 3
+        newest_version_sequence_index = 1
 
         calculation = described_class.calculate(
-          gem_name,
-          installed_version,
-          newest_version
+          installed_version_sequence_index,
+          newest_version_sequence_index
         )
         expect(calculation).to eq(2)
       end

--- a/spec/calculators/version_sequence_delta_spec.rb
+++ b/spec/calculators/version_sequence_delta_spec.rb
@@ -1,17 +1,19 @@
 require 'spec_helper'
 
-module Calculators
-  RSpec.describe VersionSequenceDelta do
-    describe '#calculate' do
-      it 'returns the number of releases between the newest and installed versions' do
-        installed_version_sequence_index = 3
-        newest_version_sequence_index = 1
+module LibyearBundler
+  module Calculators
+    RSpec.describe VersionSequenceDelta do
+      describe '#calculate' do
+        it 'returns the number of releases between the newest and installed versions' do
+          installed_version_sequence_index = 3
+          newest_version_sequence_index = 1
 
-        calculation = described_class.calculate(
-          installed_version_sequence_index,
-          newest_version_sequence_index
-        )
-        expect(calculation).to eq(2)
+          calculation = described_class.calculate(
+            installed_version_sequence_index,
+            newest_version_sequence_index
+          )
+          expect(calculation).to eq(2)
+        end
       end
     end
   end


### PR DESCRIPTION
- Use `Gem` model to hold info about gem
- Refactor `Calculators` to only require calculable args