### PR TITLE
Evaluate ruby version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,11 +6,25 @@ AllCops:
 Metrics/AbcSize:
   Max: 27
 
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+
+Metrics/ModuleLength:
+  Exclude:
+    - 'spec/**/*'
+
 Metrics/LineLength:
   Max: 100
 
 Metrics/MethodLength:
   Enabled: false
+
+Style/IndentArray:
+  EnforcedStyle: consistent
+
+Style/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
 
 Style/StringLiterals:
   Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -41,6 +41,11 @@ Layout/IndentHeredoc:
 Metrics/BlockLength:
   Max: 40
 
+# Offense count: 1
+Metrics/ClassLength:
+  Exclude:
+    - 'lib/libyear_bundler/report.rb'
+
 # Offense count: 3
 # Configuration parameters: ExpectMatchingDefinition, Regex, IgnoreExecutableScripts, AllowedAcronyms.
 # AllowedAcronyms: CLI, DSL, ACL, API, ASCII, CPU, CSS, DNS, EOF, GUID, HTML, HTTP, HTTPS, ID, IP, JSON, LHS, QPS, RAM, RHS, RPC, SLA, SMTP, SQL, SSH, TCP, TLS, TTL, UDP, UI, UID, UUID, URI, URL, UTF8, VM, XML, XMPP, XSRF, XSS

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -55,7 +55,6 @@ Style/Documentation:
   Exclude:
     - 'spec/**/*'
     - 'test/**/*'
-    - 'lib/libyear_bundler/models/gem.rb'
 
 # Offense count: 1
 # Cop supports --auto-correct.

--- a/lib/libyear_bundler/cli.rb
+++ b/lib/libyear_bundler/cli.rb
@@ -71,7 +71,7 @@ module LibyearBundler
     end
 
     def calculate_grand_total
-      if %i[libyears? releases? versions?].all? { |opt| @options[opt] }
+      if [:libyears?, :releases?, :versions?].all? { |opt| @options[opt] }
         [
           libyears_grand_total,
           releases_grand_total,

--- a/lib/libyear_bundler/cli.rb
+++ b/lib/libyear_bundler/cli.rb
@@ -3,7 +3,7 @@ require "bundler/cli/outdated"
 require "libyear_bundler/bundle_outdated"
 require "libyear_bundler/options"
 require "libyear_bundler/report"
-
+require 'libyear_bundler/models/ruby'
 
 module LibyearBundler
   # The `libyear-bundler` command line program
@@ -58,7 +58,12 @@ module LibyearBundler
     end
 
     def report
-      @_report ||= Report.new(bundle_outdated, @options)
+      @_report ||= Report.new(bundle_outdated, ruby, @options)
+    end
+
+    def ruby
+      lockfile = @gemfile_path + '.lock'
+      ::LibyearBundler::Models::Ruby.new(lockfile)
     end
 
     def grand_total
@@ -82,7 +87,7 @@ module LibyearBundler
     end
 
     def libyears_grand_total
-      report.to_h[:sum_years].truncate(1)
+      report.to_h[:sum_libyears].truncate(1)
     end
 
     def releases_grand_total

--- a/lib/libyear_bundler/cli.rb
+++ b/lib/libyear_bundler/cli.rb
@@ -71,7 +71,7 @@ module LibyearBundler
     end
 
     def calculate_grand_total
-      if [:libyears?, :releases?, :versions?].all? { |opt| @options[opt] }
+      if %i[libyears? releases? versions?].all? { |opt| @options[opt] }
         [
           libyears_grand_total,
           releases_grand_total,

--- a/lib/libyear_bundler/cli.rb
+++ b/lib/libyear_bundler/cli.rb
@@ -53,12 +53,12 @@ module LibyearBundler
       end
     end
 
-    def query
+    def bundle_outdated
       BundleOutdated.new(@gemfile_path).execute
     end
 
     def report
-      @_report ||= Report.new(query, @options)
+      @_report ||= Report.new(bundle_outdated, @options)
     end
 
     def grand_total

--- a/lib/libyear_bundler/models/gem.rb
+++ b/lib/libyear_bundler/models/gem.rb
@@ -4,6 +4,8 @@ require 'json'
 
 module LibyearBundler
   module Models
+    # Logic and information pertaining to the installed and newest versions of
+    # a gem
     class Gem
       def initialize(name, installed_version, newest_version)
         @name = name

--- a/lib/libyear_bundler/models/ruby.rb
+++ b/lib/libyear_bundler/models/ruby.rb
@@ -113,7 +113,7 @@ module LibyearBundler
         ruby_version_string = ::Bundler::LockfileParser.new(@lockfile).ruby_version
         return if ruby_version_string.nil?
 
-        ::Bundler::RubyVersion.from_string(ruby_version_string).gem_version.release
+        ::Bundler::RubyVersion.from_string(ruby_version_string).gem_version
       end
 
       def version_from_ruby_version_file
@@ -122,7 +122,7 @@ module LibyearBundler
       end
 
       def version_from_ruby
-        ::Gem::Version.new(shell_out_to_ruby).release
+        ::Gem::Version.new(shell_out_to_ruby)
       end
 
       def versions_sequence

--- a/lib/libyear_bundler/models/ruby.rb
+++ b/lib/libyear_bundler/models/ruby.rb
@@ -18,7 +18,9 @@ module LibyearBundler
 
       def installed_version
         @_installed_version ||= begin
-          version_from_bundler || version_from_rbenv || version_from_ruby
+          version_from_bundler ||
+            version_from_ruby_version_file ||
+            version_from_ruby
         end
       end
 
@@ -103,10 +105,6 @@ module LibyearBundler
         v['date']
       end
 
-      def shell_out_to_rbenv
-        'rbenv version-name'
-      end
-
       def shell_out_to_ruby
         `ruby --version`.split[1]
       end
@@ -118,9 +116,9 @@ module LibyearBundler
         ::Bundler::RubyVersion.from_string(ruby_version_string).gem_version.release
       end
 
-      def version_from_rbenv
-        stdout, _stderr, status = ::Open3.capture3(shell_out_to_rbenv)
-        ::Gem::Version.new(stdout).release if status.success?
+      def version_from_ruby_version_file
+        return unless ::File.exist?('.ruby-version')
+        ::Gem::Version.new(::File.read('.ruby-version'))
       end
 
       def version_from_ruby

--- a/lib/libyear_bundler/models/ruby.rb
+++ b/lib/libyear_bundler/models/ruby.rb
@@ -2,7 +2,6 @@ require 'bundler/lockfile_parser'
 require 'bundler/ruby_version'
 require 'date'
 require 'net/http'
-require 'open3'
 require 'yaml'
 
 require 'libyear_bundler/calculators/libyear'
@@ -118,7 +117,7 @@ module LibyearBundler
 
       def version_from_ruby_version_file
         return unless ::File.exist?('.ruby-version')
-        ::Gem::Version.new(::File.read('.ruby-version'))
+        ::Gem::Version.new(::File.read('.ruby-version').strip)
       end
 
       def version_from_ruby

--- a/lib/libyear_bundler/models/ruby.rb
+++ b/lib/libyear_bundler/models/ruby.rb
@@ -39,13 +39,8 @@ module LibyearBundler
         'ruby'
       end
 
-      # We'll only consider non-prerelease versions when determining the
-      # newest version
       def newest_version
-        newest = all_versions.detect do |version|
-          !::Gem::Version.new(version['version']).prerelease?
-        end
-        ::Gem::Version.new(newest['version'])
+        ::Gem::Version.new(all_versions.first['version'])
       end
 
       def newest_version_release_date
@@ -72,6 +67,9 @@ module LibyearBundler
 
       private
 
+      # We'll only consider non-prerelease versions when determining the
+      # newest version
+      #
       # The following URL is the only official, easily-parseable document with
       # Ruby version information that I'm aware of, but is not supported as such
       # (https://github.com/ruby/www.ruby-lang.org/pull/1637#issuecomment-344934173).
@@ -86,7 +84,9 @@ module LibyearBundler
           # The Date object is passed through here due to a bug where in
           # YAML#safe_load
           # https://github.com/ruby/psych/issues/262
-          ::YAML.safe_load(response.body, [Date])
+          ::YAML.safe_load(response.body, [Date]).reject do |version|
+            ::Gem::Version.new(version['version']).prerelease?
+          end
         end
       end
 

--- a/lib/libyear_bundler/models/ruby.rb
+++ b/lib/libyear_bundler/models/ruby.rb
@@ -109,6 +109,7 @@ module LibyearBundler
       end
 
       def version_from_bundler
+        return if @lockfile.nil?
         ruby_version_string = ::Bundler::LockfileParser.new(@lockfile).ruby_version
         return if ruby_version_string.nil?
 

--- a/lib/libyear_bundler/models/ruby.rb
+++ b/lib/libyear_bundler/models/ruby.rb
@@ -11,6 +11,9 @@ require 'libyear_bundler/calculators/version_sequence_delta'
 module LibyearBundler
   module Models
     class Ruby
+      RUBY_VERSION_DATA_URL = "https://raw.githubusercontent.com/ruby/" \
+        "www.ruby-lang.org/master/_data/releases.yml".freeze
+
       def initialize(lockfile)
         @lockfile = lockfile
       end
@@ -78,7 +81,7 @@ module LibyearBundler
       # available.
       def all_versions
         @_all_versions ||= begin
-          uri = ::URI.parse("https://raw.githubusercontent.com/ruby/www.ruby-lang.org/master/_data/releases.yml")
+          uri = ::URI.parse(RUBY_VERSION_DATA_URL)
           response = ::Net::HTTP.get_response(uri)
           # The Date object is passed through here due to a bug in
           # YAML#safe_load

--- a/lib/libyear_bundler/models/ruby.rb
+++ b/lib/libyear_bundler/models/ruby.rb
@@ -112,7 +112,7 @@ module LibyearBundler
       end
 
       def version_from_bundler
-        return unless File.exists?(@lockfile)
+        return unless File.exist?(@lockfile)
         ruby_version_string = ::Bundler::LockfileParser
           .new(@lockfile)
           .ruby_version

--- a/lib/libyear_bundler/models/ruby.rb
+++ b/lib/libyear_bundler/models/ruby.rb
@@ -1,0 +1,123 @@
+require 'bundler/lockfile_parser'
+require 'bundler/ruby_version'
+require 'date'
+require 'net/http'
+require 'open3'
+require 'yaml'
+
+require 'libyear_bundler/calculators/libyear'
+require 'libyear_bundler/calculators/version_number_delta'
+require 'libyear_bundler/calculators/version_sequence_delta'
+
+module LibyearBundler
+  module Models
+    class Ruby
+      def initialize(lockfile)
+        @lockfile = lockfile
+      end
+
+      def installed_version
+        @_installed_version ||= begin
+          version_from_bundler || version_from_rbenv || version_from_ruby
+        end
+      end
+
+      def libyears
+        ::LibyearBundler::Calculators::Libyear.calculate(
+          release_date(installed_version.to_s),
+          release_date(newest_version.to_s)
+        )
+      end
+
+      # We'll only consider non-prerelease versions when determining the
+      # newest version
+      def newest_version
+        newest = all_versions.detect do |version|
+          !::Gem::Version.new(version['version']).prerelease?
+        end
+        ::Gem::Version.new(newest['version'])
+      end
+
+      def version_number_delta
+        ::LibyearBundler::Calculators::VersionNumberDelta.calculate(
+          installed_version,
+          newest_version
+        )
+      end
+
+      def version_sequence_delta
+        ::LibyearBundler::Calculators::VersionSequenceDelta.calculate(
+          installed_version_sequence_index,
+          newest_version_sequence_index
+        )
+      end
+
+      private
+
+      # The following URL is the only official, easily-parseable document with
+      # Ruby version information that I'm aware of, but is not supported as such
+      # (https://github.com/ruby/www.ruby-lang.org/pull/1637#issuecomment-344934173).
+      # It's been recommend that ruby-lang.org provide a supported document:
+      # https://github.com/ruby/www.ruby-lang.org/pull/1637#issuecomment-344934173
+      # TODO: Use supported document with version information if it becomes
+      # available.
+      def all_versions
+        @_all_versions ||= begin
+          uri = ::URI.parse("https://raw.githubusercontent.com/ruby/www.ruby-lang.org/master/_data/releases.yml")
+          response = ::Net::HTTP.get_response(uri)
+          # The Date object is passed through here due to a bug where in
+          # YAML#safe_load
+          # https://github.com/ruby/psych/issues/262
+          ::YAML.safe_load(response.body, [Date])
+        end
+      end
+
+      def installed_version_sequence_index
+        versions_sequence.index(installed_version.to_s)
+      end
+
+      def newest_version_release_date
+        release_date(newest_version.to_s)
+      end
+
+      def newest_version_sequence_index
+        versions_sequence.index(newest_version.to_s)
+      end
+
+      def release_date(version)
+        v = all_versions.detect { |ver| ver['version'] == version }
+        # YAML#safe_load provides an already-parsed Date object, so the following
+        # is a Date object
+        v['date']
+      end
+
+      def shell_out_to_rbenv
+        'rbenv version-name'
+      end
+
+      def shell_out_to_ruby
+        `ruby --version`.split[1]
+      end
+
+      def version_from_bundler
+        ruby_version_string = ::Bundler::LockfileParser.new(@lockfile).ruby_version
+        return if ruby_version_string.nil?
+
+        ::Bundler::RubyVersion.from_string(ruby_version_string).gem_version.release
+      end
+
+      def version_from_rbenv
+        stdout, _stderr, status = ::Open3.capture3(shell_out_to_rbenv)
+        ::Gem::Version.new(stdout).release if status.success?
+      end
+
+      def version_from_ruby
+        ::Gem::Version.new(shell_out_to_ruby).release
+      end
+
+      def versions_sequence
+        all_versions.map { |version| version['version'] }
+      end
+    end
+  end
+end

--- a/lib/libyear_bundler/models/ruby.rb
+++ b/lib/libyear_bundler/models/ruby.rb
@@ -81,7 +81,7 @@ module LibyearBundler
         @_all_versions ||= begin
           uri = ::URI.parse("https://raw.githubusercontent.com/ruby/www.ruby-lang.org/master/_data/releases.yml")
           response = ::Net::HTTP.get_response(uri)
-          # The Date object is passed through here due to a bug where in
+          # The Date object is passed through here due to a bug in
           # YAML#safe_load
           # https://github.com/ruby/psych/issues/262
           ::YAML.safe_load(response.body, [Date]).reject do |version|

--- a/lib/libyear_bundler/models/ruby.rb
+++ b/lib/libyear_bundler/models/ruby.rb
@@ -110,7 +110,9 @@ module LibyearBundler
 
       def version_from_bundler
         return if @lockfile.nil?
-        ruby_version_string = ::Bundler::LockfileParser.new(@lockfile).ruby_version
+        ruby_version_string = ::Bundler::LockfileParser
+          .new(@lockfile)
+          .ruby_version
         return if ruby_version_string.nil?
 
         ::Bundler::RubyVersion.from_string(ruby_version_string).gem_version

--- a/lib/libyear_bundler/models/ruby.rb
+++ b/lib/libyear_bundler/models/ruby.rb
@@ -22,6 +22,10 @@ module LibyearBundler
         end
       end
 
+      def installed_version_release_date
+        release_date(installed_version.to_s)
+      end
+
       def libyears
         ::LibyearBundler::Calculators::Libyear.calculate(
           release_date(installed_version.to_s),
@@ -40,6 +44,14 @@ module LibyearBundler
           !::Gem::Version.new(version['version']).prerelease?
         end
         ::Gem::Version.new(newest['version'])
+      end
+
+      def newest_version_release_date
+        release_date(newest_version.to_s)
+      end
+
+      def outdated?
+        installed_version != newest_version
       end
 
       def version_number_delta
@@ -78,10 +90,6 @@ module LibyearBundler
 
       def installed_version_sequence_index
         versions_sequence.index(installed_version.to_s)
-      end
-
-      def newest_version_release_date
-        release_date(newest_version.to_s)
       end
 
       def newest_version_sequence_index

--- a/lib/libyear_bundler/models/ruby.rb
+++ b/lib/libyear_bundler/models/ruby.rb
@@ -10,6 +10,7 @@ require 'libyear_bundler/calculators/version_sequence_delta'
 
 module LibyearBundler
   module Models
+    # Logic and information pertaining to the installed and newest Ruby versions
     class Ruby
       RUBY_VERSION_DATA_URL = "https://raw.githubusercontent.com/ruby/" \
         "www.ruby-lang.org/master/_data/releases.yml".freeze

--- a/lib/libyear_bundler/models/ruby.rb
+++ b/lib/libyear_bundler/models/ruby.rb
@@ -29,6 +29,10 @@ module LibyearBundler
         )
       end
 
+      def name
+        'ruby'
+      end
+
       # We'll only consider non-prerelease versions when determining the
       # newest version
       def newest_version

--- a/lib/libyear_bundler/models/ruby.rb
+++ b/lib/libyear_bundler/models/ruby.rb
@@ -51,7 +51,7 @@ module LibyearBundler
       end
 
       def outdated?
-        installed_version != newest_version
+        installed_version < newest_version
       end
 
       def version_number_delta

--- a/lib/libyear_bundler/models/ruby.rb
+++ b/lib/libyear_bundler/models/ruby.rb
@@ -112,7 +112,7 @@ module LibyearBundler
       end
 
       def version_from_bundler
-        return if @lockfile.nil?
+        return unless File.exists?(@lockfile)
         ruby_version_string = ::Bundler::LockfileParser
           .new(@lockfile)
           .ruby_version

--- a/lib/libyear_bundler/options.rb
+++ b/lib/libyear_bundler/options.rb
@@ -6,7 +6,7 @@ require 'ostruct'
 module LibyearBundler
   # Uses OptionParser from Ruby's stdlib to hand command-line arguments
   class Options
-    BANNER = <<-BANNER
+    BANNER = <<-BANNER.freeze
 Usage: libyear-bundler [Gemfile ...] [options]
 https://github.com/jaredbeck/libyear-bundler/
     BANNER

--- a/lib/libyear_bundler/report.rb
+++ b/lib/libyear_bundler/report.rb
@@ -28,23 +28,21 @@ module LibyearBundler
             gems: @gems,
             sum_libyears: 0.0
           }
-          @gems.each_with_object(summary) do |gem, memo|
-            increment_libyears(gem, memo) if @options.libyears?
-            increment_version_deltas(gem, memo) if @options.versions?
-            increment_seq_deltas(gem, memo) if @options.releases?
-          end
+          @gems.each { |gem| increment_metrics_summary(gem, summary) }
 
-          if @ruby.outdated?
-            increment_libyears(@ruby, summary) if @options.libyears?
-            increment_version_deltas(@ruby, summary) if @options.versions?
-            increment_seq_deltas(@ruby, summary) if @options.releases?
-          end
+          increment_metrics_summary(@ruby, summary) if @ruby.outdated?
 
           summary
         end
     end
 
     private
+
+    def increment_metrics_summary(model, summary)
+      increment_libyears(model, summary) if @options.libyears?
+      increment_version_deltas(model, summary) if @options.versions?
+      increment_seq_deltas(model, summary) if @options.releases?
+    end
 
     def put_line_summary(gem_or_ruby)
       meta = meta_line_summary(gem_or_ruby)

--- a/lib/libyear_bundler/report.rb
+++ b/lib/libyear_bundler/report.rb
@@ -96,7 +96,7 @@ module LibyearBundler
     end
 
     def put_summary(summary)
-      if [:libyears?, :releases?, :versions?].all? { |opt| @options.send(opt) }
+      if %i[libyears? releases? versions?].all? { |opt| @options.send(opt) }
         put_libyear_summary(summary[:sum_years])
         put_sum_seq_delta_summary(summary[:sum_seq_delta])
         put_version_delta_summary(

--- a/lib/libyear_bundler/report.rb
+++ b/lib/libyear_bundler/report.rb
@@ -9,13 +9,14 @@ module LibyearBundler
 
     # `gems` - Array of `::LibyearBundler::Models::Gem` instances
     # `options` - Instance of `::LibyearBundler::Options`
-    def initialize(gems, options)
+    def initialize(gems, ruby, options)
       @gems = gems
       @options = options
     end
 
     def to_s
-      to_h[:gems].each { |gem| put_gem_summary(gem) }
+      to_h[:gems].each { |gem| put_line_summary(gem) }
+      put_line_summar(@ruby)
       put_summary(to_h)
     end
 
@@ -48,35 +49,35 @@ module LibyearBundler
 
     private
 
-    def put_gem_summary(gem)
-      meta = meta_gem_summary(gem)
+    def put_line_summary(gem_or_ruby)
+      meta = meta_line_summary(gem_or_ruby)
 
       if @options.releases?
-        releases = format(FMT_RELEASES_COLUMN, gem.version_sequence_delta)
+        releases = format(FMT_RELEASES_COLUMN, gem_or_ruby.version_sequence_delta)
         meta << releases
       end
 
       if @options.versions?
-        versions = format(FMT_VERSIONS_COLUMN, gem.version_number_delta)
+        versions = format(FMT_VERSIONS_COLUMN, gem_or_ruby.version_number_delta)
         meta << versions
       end
 
       if @options.libyears?
-        libyears = format(FMT_LIBYEARS_COLUMN, gem.libyears)
+        libyears = format(FMT_LIBYEARS_COLUMN, gem_or_ruby.libyears)
         meta << libyears
       end
 
       puts meta
     end
 
-    def meta_gem_summary(gem)
+    def meta_line_summary(gem_or_ruby)
       format(
         FMT_SUMMARY_COLUMNS,
-        gem.name,
-        gem.installed_version.to_s,
-        gem.installed_version_release_date,
-        gem.newest_version.to_s,
-        gem.newest_version_release_date
+        gem_or_ruby.name,
+        gem_or_ruby.installed_version.to_s,
+        gem_or_ruby.installed_version_release_date,
+        gem_or_ruby.newest_version.to_s,
+        gem_or_ruby.newest_version_release_date
       )
     end
 

--- a/lib/libyear_bundler/report.rb
+++ b/lib/libyear_bundler/report.rb
@@ -1,6 +1,6 @@
 module LibyearBundler
-  # Responsible presenting data from the `Query`. Should only be concerned
-  # with presentation, nothing else.
+  # Responsible presenting data from the `::LibyearBundler::Models`. Should only
+  # be concerned with presentation, nothing else.
   class Report
     FMT_LIBYEARS_COLUMN = "%10.1f".freeze
     FMT_RELEASES_COLUMN = "%10d".freeze

--- a/lib/libyear_bundler/report.rb
+++ b/lib/libyear_bundler/report.rb
@@ -33,6 +33,10 @@ module LibyearBundler
             sum_version_deltas(gem, memo) if @options.versions?
             sum_seq_deltas(gem, memo) if @options.releases?
           end
+
+          sum_ruby(summary) if @ruby.outdated?
+
+          summary
         end
     end
 
@@ -111,14 +115,23 @@ module LibyearBundler
 
     def sum_libyears(gem, memo)
       memo[:sum_libyears] += gem.libyears
-      memo[:sum_libyears] += @ruby.libyears if @ruby.outdated?
+    end
+
+    def sum_ruby(memo)
+      memo[:sum_libyears] += @ruby.libyears if @options.libyears?
+      memo[:sum_seq_delta] += @ruby.version_sequence_delta if @options.releases?
+
+      if @options.versions?
+        memo[:sum_major_version] += @ruby.version_number_delta[0]
+        memo[:sum_minor_version] += @ruby.version_number_delta[1]
+        memo[:sum_patch_version] += @ruby.version_number_delta[2]
+      end
+
     end
 
     def sum_seq_deltas(gem, memo)
       memo[:sum_seq_delta] ||= 0
       memo[:sum_seq_delta] += gem.version_sequence_delta
-
-      memo[:sum_seq_delta] += @ruby.version_sequence_delta if @ruby.outdated?
     end
 
     def sum_version_deltas(gem, memo)
@@ -128,12 +141,6 @@ module LibyearBundler
       memo[:sum_minor_version] += gem.version_number_delta[1]
       memo[:sum_patch_version] ||= 0
       memo[:sum_patch_version] += gem.version_number_delta[2]
-
-      if @ruby.outdated?
-        memo[:sum_major_version] += @ruby.version_number_delta[0]
-        memo[:sum_minor_version] += @ruby.version_number_delta[1]
-        memo[:sum_patch_version] += @ruby.version_number_delta[2]
-      end
     end
   end
 end

--- a/lib/libyear_bundler/report.rb
+++ b/lib/libyear_bundler/report.rb
@@ -7,7 +7,7 @@ module LibyearBundler
     FMT_VERSIONS_COLUMN = "%15s".freeze
     FMT_SUMMARY_COLUMNS = "%30s%15s%15s%15s%15s".freeze
 
-    # `gems` - Array of hashes.
+    # `gems` - Array of `::LibyearBundler::Models::Gem` instances
     def initialize(gems, options)
       @gems = gems
       @options = options

--- a/lib/libyear_bundler/report.rb
+++ b/lib/libyear_bundler/report.rb
@@ -30,8 +30,8 @@ module LibyearBundler
           }
           @gems.each_with_object(summary) do |gem, memo|
             increment_libyears(gem, memo) if @options.libyears?
-            sum_version_deltas(gem, memo) if @options.versions?
-            sum_seq_deltas(gem, memo) if @options.releases?
+            increment_version_deltas(gem, memo) if @options.versions?
+            increment_seq_deltas(gem, memo) if @options.releases?
           end
 
           sum_ruby(summary) if @ruby.outdated?
@@ -129,12 +129,12 @@ module LibyearBundler
 
     end
 
-    def sum_seq_deltas(gem, memo)
+    def increment_seq_deltas(gem, memo)
       memo[:sum_seq_delta] ||= 0
       memo[:sum_seq_delta] += gem.version_sequence_delta
     end
 
-    def sum_version_deltas(gem, memo)
+    def increment_version_deltas(gem, memo)
       memo[:sum_major_version] ||= 0
       memo[:sum_major_version] += gem.version_number_delta[0]
       memo[:sum_minor_version] ||= 0

--- a/lib/libyear_bundler/report.rb
+++ b/lib/libyear_bundler/report.rb
@@ -34,7 +34,11 @@ module LibyearBundler
             increment_seq_deltas(gem, memo) if @options.releases?
           end
 
-          sum_ruby(summary) if @ruby.outdated?
+          if @ruby.outdated?
+            increment_libyears(@ruby, summary) if @options.libyears?
+            increment_version_deltas(@ruby, summary) if @options.versions?
+            increment_seq_deltas(@ruby, summary) if @options.releases?
+          end
 
           summary
         end
@@ -113,34 +117,22 @@ module LibyearBundler
       end
     end
 
-    def increment_libyears(gem, memo)
-      memo[:sum_libyears] += gem.libyears
+    def increment_libyears(model, memo)
+      memo[:sum_libyears] += model.libyears
     end
 
-    def sum_ruby(memo)
-      memo[:sum_libyears] += @ruby.libyears if @options.libyears?
-      memo[:sum_seq_delta] += @ruby.version_sequence_delta if @options.releases?
-
-      if @options.versions?
-        memo[:sum_major_version] += @ruby.version_number_delta[0]
-        memo[:sum_minor_version] += @ruby.version_number_delta[1]
-        memo[:sum_patch_version] += @ruby.version_number_delta[2]
-      end
-
-    end
-
-    def increment_seq_deltas(gem, memo)
+    def increment_seq_deltas(model, memo)
       memo[:sum_seq_delta] ||= 0
-      memo[:sum_seq_delta] += gem.version_sequence_delta
+      memo[:sum_seq_delta] += model.version_sequence_delta
     end
 
-    def increment_version_deltas(gem, memo)
+    def increment_version_deltas(model, memo)
       memo[:sum_major_version] ||= 0
-      memo[:sum_major_version] += gem.version_number_delta[0]
+      memo[:sum_major_version] += model.version_number_delta[0]
       memo[:sum_minor_version] ||= 0
-      memo[:sum_minor_version] += gem.version_number_delta[1]
+      memo[:sum_minor_version] += model.version_number_delta[1]
       memo[:sum_patch_version] ||= 0
-      memo[:sum_patch_version] += gem.version_number_delta[2]
+      memo[:sum_patch_version] += model.version_number_delta[2]
     end
   end
 end

--- a/lib/libyear_bundler/report.rb
+++ b/lib/libyear_bundler/report.rb
@@ -8,6 +8,7 @@ module LibyearBundler
     FMT_SUMMARY_COLUMNS = "%30s%15s%15s%15s%15s".freeze
 
     # `gems` - Array of `::LibyearBundler::Models::Gem` instances
+    # `options` - Instance of `::LibyearBundler::Options`
     def initialize(gems, options)
       @gems = gems
       @options = options

--- a/lib/libyear_bundler/report.rb
+++ b/lib/libyear_bundler/report.rb
@@ -29,7 +29,7 @@ module LibyearBundler
             sum_libyears: 0.0
           }
           @gems.each_with_object(summary) do |gem, memo|
-            sum_libyears(gem, memo) if @options.libyears?
+            increment_libyears(gem, memo) if @options.libyears?
             sum_version_deltas(gem, memo) if @options.versions?
             sum_seq_deltas(gem, memo) if @options.releases?
           end
@@ -113,7 +113,7 @@ module LibyearBundler
       end
     end
 
-    def sum_libyears(gem, memo)
+    def increment_libyears(gem, memo)
       memo[:sum_libyears] += gem.libyears
     end
 

--- a/lib/libyear_bundler/report.rb
+++ b/lib/libyear_bundler/report.rb
@@ -94,7 +94,7 @@ module LibyearBundler
     end
 
     def put_summary(summary)
-      if %i[libyears? releases? versions?].all? { |opt| @options.send(opt) }
+      if [:libyears?, :releases?, :versions?].all? { |opt| @options.send(opt) }
         put_libyear_summary(summary[:sum_years])
         put_sum_seq_delta_summary(summary[:sum_seq_delta])
         put_version_delta_summary(

--- a/lib/libyear_bundler/report.rb
+++ b/lib/libyear_bundler/report.rb
@@ -5,6 +5,7 @@ module LibyearBundler
     FMT_LIBYEARS_COLUMN = "%10.1f".freeze
     FMT_RELEASES_COLUMN = "%10d".freeze
     FMT_VERSIONS_COLUMN = "%15s".freeze
+    FMT_SUMMARY_COLUMNS = "%30s%15s%15s%15s%15s".freeze
 
     # `gems` - Array of hashes.
     def initialize(gems, options)
@@ -69,7 +70,7 @@ module LibyearBundler
 
     def meta_gem_summary(gem)
       format(
-        "%30s%15s%15s%15s%15s",
+        FMT_SUMMARY_COLUMNS,
         gem.name,
         gem.installed_version.to_s,
         gem.installed_version_release_date,

--- a/spec/calculators/libyear_spec.rb
+++ b/spec/calculators/libyear_spec.rb
@@ -9,8 +9,8 @@ module LibyearBundler
           installed_date = Date.new(2016, 1, 1)
           newest_date = Date.new(2017, 1, 1)
 
-          expect(described_class.calculate(installed_date, newest_date)).
-            to be_within(0.01).of(1.00)
+          expect(described_class.calculate(installed_date, newest_date))
+            .to be_within(0.01).of(1.00)
         end
       end
     end

--- a/spec/models/gem_spec.rb
+++ b/spec/models/gem_spec.rb
@@ -93,7 +93,7 @@ module LibyearBundler
           gem = described_class.new(nil, installed_version, newest_version)
           allow(gem)
             .to receive(:versions_sequence)
-            .and_return([newest_version,installed_version])
+            .and_return([newest_version, installed_version])
           expect(gem.version_sequence_delta).to eq(1)
         end
       end

--- a/spec/models/gem_spec.rb
+++ b/spec/models/gem_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+
+module LibyearBundler
+  module Models
+    RSpec.describe Gem do
+      describe '#installed_version' do
+        it 'returns the installed version' do
+          newest_version = '1.0.0'
+          gem = described_class.new(nil, newest_version, nil)
+          expect(gem.installed_version).to eq(::Gem::Version.new(newest_version))
+        end
+      end
+
+      describe '#installed_version_release_date' do
+        it 'returns the release date of the installed version' do
+          date = Date.new(2017, 1, 1)
+          gem = described_class.new(nil, nil, nil)
+          allow(gem).to receive(:release_date).and_return(date)
+          expect(gem.installed_version_release_date).to eq(date)
+        end
+      end
+
+      describe '#installed_version_sequence_index' do
+        it 'returns the index' do
+          installed_version = '1.0.0'
+          newest_version = '2.0.0'
+          gem = described_class.new(nil, installed_version, newest_version)
+          allow(gem)
+            .to receive(:versions_sequence)
+            .and_return([newest_version, installed_version])
+          expect(gem.installed_version_sequence_index).to eq(1)
+        end
+      end
+
+      describe '#libyears' do
+        it 'returns the number of years out of date' do
+          allow(::LibyearBundler::Calculators::Libyear)
+            .to receive(:calculate)
+            .and_return(1)
+          gem = described_class.new(nil, nil, nil)
+          allow(gem).to receive(:libyears).and_return(1)
+        end
+      end
+
+      describe '#name' do
+        it 'returns the gem name' do
+          gem_name = 'gem_name'
+          gem = described_class.new(gem_name, nil, nil)
+          expect(gem.name).to eq(gem_name)
+        end
+      end
+
+      describe '#newest_version' do
+        it 'returns the newest version' do
+          newest_version = '2.0.0'
+          gem = described_class.new(nil, nil, newest_version)
+          expect(gem.newest_version).to eq(::Gem::Version.new(newest_version))
+        end
+      end
+
+      describe '#newest_version_release_date' do
+        it 'returns the release date of the newest version' do
+          date = Date.new(2017, 1, 1)
+          gem = described_class.new(nil, nil, nil)
+          allow(gem).to receive(:release_date).and_return(date)
+          expect(gem.newest_version_release_date).to eq(date)
+        end
+      end
+
+      describe '#newest_version_sequence_index' do
+        it 'returns the index' do
+          installed_version = '1.0.0'
+          newest_version = '2.0.0'
+          gem = described_class.new(nil, installed_version, newest_version)
+          allow(gem)
+            .to receive(:versions_sequence)
+            .and_return([newest_version, installed_version])
+          expect(gem.newest_version_sequence_index).to eq(0)
+        end
+      end
+
+      describe '#version_number_delta' do
+        it 'returns an array of the major, minor, and patch versions out-of-date' do
+          gem = described_class.new(nil, '1.0.0', '2.0.0')
+          expect(gem.version_number_delta).to eq([1, 0, 0])
+        end
+      end
+
+      describe '#version_sequence_delta' do
+        it 'returns the number of releases between versions' do
+          installed_version = '1.0.0'
+          newest_version = '2.0.0'
+          gem = described_class.new(nil, installed_version, newest_version)
+          allow(gem)
+            .to receive(:versions_sequence)
+            .and_return([newest_version,installed_version])
+          expect(gem.version_sequence_delta).to eq(1)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/ruby_spec.rb
+++ b/spec/models/ruby_spec.rb
@@ -1,0 +1,145 @@
+require 'spec_helper'
+
+module LibyearBundler
+  module Models
+    RSpec.describe Ruby do
+      describe '#installed_version' do
+        it 'gets the version from bundler' do
+          ruby_version = '2.4.2'
+          ruby = described_class.new(nil)
+          allow(ruby).to receive(:version_from_bundler).and_return(ruby_version)
+          expect(ruby.installed_version).to eq(ruby_version)
+        end
+
+        it 'gets the version from .ruby-version file' do
+          ruby_version = '2.4.2'
+          ruby = described_class.new(nil)
+          allow(ruby).to receive(:version_from_bundler).and_return(nil)
+          allow(ruby).to receive(:version_from_ruby_version_file).and_return(ruby_version)
+          expect(ruby.installed_version).to eq(ruby_version)
+        end
+
+        it 'gets the version from ruby' do
+          ruby_version = '2.4.2'
+          ruby = described_class.new(nil)
+          allow(ruby).to receive(:version_from_bundler).and_return(nil)
+          allow(ruby).to receive(:version_from_ruby_version_file).and_return(nil)
+          allow(ruby).to receive(:version_from_ruby).and_return(ruby_version)
+          expect(ruby.installed_version).to eq(ruby_version)
+        end
+      end
+
+      describe '#installed_version_release_date' do
+        it 'returns the release date for the installed version' do
+          date = Date.new(2017, 1, 1)
+          ruby = described_class.new(nil)
+          allow(ruby)
+            .to receive(:release_date)
+            .and_return(date)
+          allow(ruby).to receive(:installed_version)
+          expect(ruby.installed_version_release_date).to eq(date)
+        end
+      end
+
+      describe '#libyears' do
+        it 'returns the number of years out-of-date' do
+          installed_version_release_date = Date.new(2017, 1, 1)
+          newest_version_release_date = Date.new(2018, 1, 1)
+          ruby = described_class.new(nil)
+          allow(ruby)
+            .to receive(:release_date)
+            .and_return(
+              installed_version_release_date,
+              newest_version_release_date
+            )
+          allow(ruby).to receive(:installed_version)
+          expect(ruby.libyears).to eq(1)
+        end
+      end
+
+      describe '#name' do
+        it 'returns "ruby"' do
+          expect(described_class.new(nil).name).to eq('ruby')
+        end
+      end
+
+      describe '#newest_version' do
+        it 'returns the newest version' do
+          newest_version = '2.4.2'
+          ruby = described_class.new(nil)
+          allow(ruby)
+            .to receive(:all_versions)
+            .and_return([{ 'version' => newest_version }])
+          expect(ruby.newest_version).to eq(::Gem::Version.new(newest_version))
+        end
+
+        context 'newest version is a pre-release' do
+          it 'returns the newest non-pre-release version' do
+            newest_prerelease_version = '2.5.0-preview1'
+            newest_version = '2.4.2'
+            ruby = described_class.new(nil)
+            allow(ruby)
+              .to receive(:all_versions)
+              .and_return([
+                { 'version' => newest_prerelease_version },
+                { 'version' => newest_version }
+              ])
+            expect(ruby.newest_version).to eq(::Gem::Version.new(newest_version))
+          end
+        end
+      end
+
+      describe '#newest_version_release_date' do
+        it 'returns the release date for the newest version' do
+          date = Date.new(2017, 1, 1)
+          ruby = described_class.new(nil)
+          allow(ruby)
+            .to receive(:release_date)
+            .and_return(date)
+          allow(ruby).to receive(:installed_version)
+          expect(ruby.newest_version_release_date).to eq(date)
+        end
+      end
+
+      describe '#outdated?' do
+        it 'returns true if installed version is less than newest version' do
+          installed_version = ::Gem::Version.new('1.0.0')
+          newest_version = ::Gem::Version.new('2.0.0')
+          ruby = described_class.new(nil)
+          allow(ruby).to receive(:installed_version).and_return(installed_version)
+          allow(ruby).to receive(:newest_version).and_return(newest_version)
+          expect(ruby.outdated?).to eq(true)
+        end
+
+        it 'returns false if installed version is equal to newest version' do
+          installed_version = ::Gem::Version.new('1.0.0')
+          newest_version = ::Gem::Version.new('1.0.0')
+          ruby = described_class.new(nil)
+          allow(ruby).to receive(:installed_version).and_return(installed_version)
+          allow(ruby).to receive(:newest_version).and_return(newest_version)
+          expect(ruby.outdated?).to eq(false)
+        end
+      end
+
+      describe '#version_number_delta' do
+        it 'returns the major, minor, and patch versions out-of-date' do
+          installed_version = ::Gem::Version.new('1.0.0')
+          newest_version = ::Gem::Version.new('2.0.0')
+          ruby = described_class.new(nil)
+          allow(ruby).to receive(:installed_version).and_return(installed_version)
+          allow(ruby).to receive(:newest_version).and_return(newest_version)
+          expect(ruby.version_number_delta).to eq([1, 0, 0])
+        end
+      end
+
+      describe '#version_sequence_delta' do
+        it 'returns the major, minor, and patch versions out-of-date' do
+          ruby = described_class.new(nil)
+          allow(ruby).to receive(:installed_version_sequence_index).and_return(1)
+          allow(ruby).to receive(:newest_version_sequence_index).and_return(0)
+          expect(ruby.version_sequence_delta).to eq(1)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/ruby_spec.rb
+++ b/spec/models/ruby_spec.rb
@@ -75,14 +75,14 @@ module LibyearBundler
 
         context 'newest version is a pre-release' do
           it 'returns the newest non-pre-release version' do
-            newest_prerelease_version = '2.5.0-preview1'
+            older_version = '2.4.1'
             newest_version = '2.4.2'
             ruby = described_class.new(nil)
             allow(ruby)
               .to receive(:all_versions)
               .and_return([
-                { 'version' => newest_prerelease_version },
-                { 'version' => newest_version }
+                { 'version' => newest_version },
+                { 'version' => older_version }
               ])
             expect(ruby.newest_version).to eq(::Gem::Version.new(newest_version))
           end

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -2,11 +2,41 @@ require 'spec_helper'
 
 module LibyearBundler
   RSpec.describe Options do
-    it 'sets instance vars' do
-      opts = described_class.new([])
-      expect(opts.instance_variable_get(:@argv)).to eq([])
-      expect(opts.instance_variable_get(:@options)).to be_a(::OpenStruct)
-      expect(opts.instance_variable_get(:@optparser)).to be_a(::OptionParser)
+    it 'sets libyears? to true by default' do
+      opts = described_class.new([]).parse
+      expect(opts.libyears?).to eq(true)
+    end
+
+    context '--all flag' do
+      it 'sets all options to true' do
+        opts = described_class.new(['--all']).parse
+        %i[libyears releases versions].each do |flag|
+          expect(opts.send("#{flag}?".to_sym)).to eq(true)
+        end
+      end
+    end
+
+    context '--libyears flag' do
+      it 'sets libyears? to true' do
+        opts = described_class.new(['--libyears']).parse
+        expect(opts.libyears?).to eq(true)
+      end
+    end
+
+    context '--releases flag' do
+      it 'sets libyears? to true' do
+        opts = described_class.new(['--releases']).parse
+        expect(opts.libyears?).to eq(false)
+        expect(opts.releases?).to eq(true)
+      end
+    end
+
+    context '--versions flag' do
+      it 'sets libyears? to true' do
+        opts = described_class.new(['--versions']).parse
+        expect(opts.libyears?).to eq(false)
+        expect(opts.versions?).to eq(true)
+      end
     end
 
     context 'invalid option' do
@@ -15,6 +45,13 @@ module LibyearBundler
         expect { opts.parse }
           .to raise_error(::SystemExit)
           .and(output.to_stderr)
+      end
+    end
+
+    context 'with Gemfile path' do
+      it 'sets libyears? to true by default' do
+        opts = described_class.new(['/path/to/Gemfile']).parse
+        expect(opts.libyears?).to eq(true)
       end
     end
   end

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -10,7 +10,7 @@ module LibyearBundler
     context '--all flag' do
       it 'sets all options to true' do
         opts = described_class.new(['--all']).parse
-        %i[libyears releases versions].each do |flag|
+        [:libyears, :releases, :versions].each do |flag|
           expect(opts.send("#{flag}?".to_sym)).to eq(true)
         end
       end


### PR DESCRIPTION
This addresses the ruby version part of #2. The `Ruby` model design is based off the `Gem` model. Of interest is how the ruby version is determined via `Ruby#installed_version` and how we get information for all ruby versions via `Ruby#all_versions`.

This PR also includes specs for the `Gem` and `Ruby` models and more specs for the `Options` class.

There are also various refactorings. Lemme know if you'd like to go over it in person.