### PR TITLE
update report.rb

### DIFF
--- a/lib/libyear_bundler/report.rb
+++ b/lib/libyear_bundler/report.rb
@@ -93,16 +93,16 @@ module LibyearBundler
     def put_version_delta_summary(sum_major_version, sum_minor_version, sum_patch_version)
       puts format(
         "Major, minor, patch versions behind: %<major>d, %<minor>d, %<patch>d",
-        major: sum_major_version,
-        minor: sum_minor_version,
-        patch: sum_patch_version
+        major: sum_major_version || 0,
+        minor: sum_minor_version || 0,
+        patch: sum_patch_version || 0
       )
     end
 
     def put_sum_seq_delta_summary(sum_seq_delta)
       puts format(
         "Total releases behind: %<seq_delta>d",
-        seq_delta: sum_seq_delta
+        seq_delta: sum_seq_delta || 0
       )
     end
 


### PR DESCRIPTION
Adds default values to `#put_` methods so they don't raise `TypeError` on an up-to-date proyect.

If you run `libyear-bundler --all` in an up-to-date proyect, it goes BOOM!
Providing sample repository [here](https://github.com/vaporyhumo/libyear-bug), just run the command above.