### PR TITLE
Ruby 3.1 / psych 4.0 YAML#safe_load requires permitted classes in keyword parameter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
           - '2.6'
           - '2.7'
           - '3.0'
+          - '3.1'
     steps:
       - name: Checkout source
         uses: actions/checkout@v2

--- a/lib/libyear_bundler/models/ruby.rb
+++ b/lib/libyear_bundler/models/ruby.rb
@@ -82,9 +82,15 @@ module LibyearBundler
             # The Date object is passed through here due to a bug in
             # YAML#safe_load
             # https://github.com/ruby/psych/issues/262
-            ::YAML
-              .safe_load(response.body, [Date])
-              .map { |release| release['version'] }
+            if YAML.method(:safe_load).parameters.include?([:key, :permitted_classes])
+              ::YAML
+                .safe_load(response.body, permitted_classes: [Date])
+                .map { |release| release['version'] }
+            else
+              ::YAML
+                .safe_load(response.body, [Date])
+                .map { |release| release['version'] }
+            end
           end
         end
       end

--- a/lib/libyear_bundler/release_date_cache.rb
+++ b/lib/libyear_bundler/release_date_cache.rb
@@ -21,7 +21,11 @@ module LibyearBundler
     class << self
       def load(path)
         if File.exist?(path)
-          new(YAML.safe_load(File.read(path), [Date]))
+          if YAML.method(:safe_load).parameters.include?([:key, :permitted_classes])
+            new(YAML.safe_load(File.read(path), permitted_classes: [Date]))
+          else
+            new(YAML.safe_load(File.read(path), [Date]))
+          end
         else
           new({})
         end


### PR DESCRIPTION
Since psych 4.0, `YAML#safe_load` requires the permitted classes in keyword parameter `permitted_classes`. Ruby 3.1 ships with psych 4.0.

This PR adds Ruby 3.1 to the GitHub Actions matrix, and updates the calls to `YAML#safe_load` checking if the method accepts keyword parameter `permitted_classes` (available since psych 3.1.0).

For older versions of psych (not accepting `YAML#safe_load` keyword parameter `permitted_classes`; up to psych 3.0.3), the permitted classes are specified a second positional parameter (`whitelisted_classes` psych <=3.0.3, `legacy_permitted_classes` psych >=3.1.0 <4.0.0)

Closes #22.