### PR TITLE
Add support for `--sort` cli option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ Breaking changes:
 
 Added:
 
-- None
+- [#38](https://github.com/jaredbeck/libyear-bundler/issues/38) -
+  Added support for `--sort` cli option
 
 Fixed:
 

--- a/lib/libyear_bundler/options.rb
+++ b/lib/libyear_bundler/options.rb
@@ -52,6 +52,10 @@ https://github.com/jaredbeck/libyear-bundler/
         opts.on('--grand-total', 'Return value for given metric(s)') do
           @options.send('grand_total?=', true)
         end
+
+        opts.on('--sort', 'Sort by selected metric(s), in descending order') do
+          @options.send('sort?=', true)
+        end
       end
     end
 

--- a/lib/libyear_bundler/report.rb
+++ b/lib/libyear_bundler/report.rb
@@ -31,11 +31,12 @@ module LibyearBundler
     def to_h
       @_to_h ||=
         begin
+          gems = sorted_gems(@gems)
           summary = {
-            gems: @gems,
+            gems: gems,
             sum_libyears: 0.0
           }
-          @gems.each { |gem| increment_metrics_summary(gem, summary) }
+          gems.each { |gem| increment_metrics_summary(gem, summary) }
 
           begin
             increment_metrics_summary(@ruby, summary) if @ruby.outdated?
@@ -48,6 +49,20 @@ module LibyearBundler
     end
 
     private
+
+    def sorted_gems(gems)
+      if @options.sort?
+        gems.sort_by do |gem|
+          [
+            (gem.libyears if @options.libyears?),
+            (gem.version_sequence_delta if @options.releases?),
+            (gem.version_number_delta if @options.versions?)
+          ].compact
+        end.reverse
+      else
+        gems
+      end
+    end
 
     def increment_metrics_summary(model, summary)
       increment_libyears(model, summary) if @options.libyears?

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -39,6 +39,13 @@ module LibyearBundler
       end
     end
 
+    context '--sort flag' do
+      it 'sets sort? to true' do
+        opts = described_class.new(['--sort']).parse
+        expect(opts.sort?).to eq(true)
+      end
+    end
+
     context 'invalid option' do
       it 'prints the help' do
         opts = described_class.new(['--black-flag'])

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -7,37 +7,80 @@ module LibyearBundler
   RSpec.describe Report do
     describe '#write' do
       it 'returns a tabular string with fixed-width columns' do
-        # Instead of these stubs, I considered using VCR, but that would mean
-        # committing a 7 MB cassette. Instead, I'd rather stub for now, and then
-        # think about how to eager-load all the data before running the report.
-        allow(Models::Gem).to(
-          receive(:release_date)
-            .with('rails', ::Gem::Version.new('7.1.2'))
-            .and_return(::Date.new(2023, 11, 10))
-        )
-        allow(Models::Gem).to(
-          receive(:release_date)
-            .with('rails', ::Gem::Version.new('7.1.3'))
-            .and_return(::Date.new(2024, 1, 16))
-        )
-        allow(Models::Ruby).to receive(:release_date)
-        allow(Models::Ruby).to receive(:newest_version).and_return(::Gem::Version.new('3.3.0'))
-        release_date_cache = nil
-        gem = Models::Gem.new('rails', '7.1.2', '7.1.3', release_date_cache)
-        lockfile = 'spec/fixtures/01/Gemfile.lock'
-        ruby = Models::Ruby.new(lockfile, release_date_cache)
+        ruby = stub_ruby
+        gems = [stub_pg_gem, stub_rails_gem]
         opts = Options.new([]).parse
         io = StringIO.new
-        report = described_class.new([gem], ruby, opts, io)
+        report = described_class.new(gems, ruby, opts, io)
         report.write
         expect(io.string).to eq(
           <<-EOS
-                         rails          7.1.2     2023-11-10          7.1.3     2024-01-16       0.2
+                            pg          1.5.0     2023-04-24          1.5.6     2024-03-01       0.9
+                         rails          7.0.0     2021-12-15          7.1.3     2024-01-16       2.1
                           ruby          2.4.2                         3.3.0                      0.0
-System is 0.2 libyears behind
+System is 2.9 libyears behind
           EOS
         )
       end
+
+      it 'sorts by selected metric' do
+        ruby = stub_ruby
+        gems = [stub_pg_gem, stub_rails_gem]
+        opts = Options.new(['--sort']).parse
+        io = StringIO.new
+        report = described_class.new(gems, ruby, opts, io)
+        report.write
+        expect(io.string).to eq(
+          <<-EOS
+                         rails          7.0.0     2021-12-15          7.1.3     2024-01-16       2.1
+                            pg          1.5.0     2023-04-24          1.5.6     2024-03-01       0.9
+                          ruby          2.4.2                         3.3.0                      0.0
+System is 2.9 libyears behind
+          EOS
+        )
+      end
+    end
+
+    private
+
+    # Instead of these stubs, I considered using VCR, but that would mean
+    # committing a 7 MB cassette. Instead, I'd rather stub for now, and then
+    # think about how to eager-load all the data before running the report.
+    def stub_ruby
+      allow(Models::Ruby).to receive(:release_date)
+      allow(Models::Ruby).to receive(:newest_version).and_return(::Gem::Version.new('3.3.0'))
+      lockfile = 'spec/fixtures/01/Gemfile.lock'
+      Models::Ruby.new(lockfile, nil)
+    end
+
+    def stub_pg_gem
+      allow(Models::Gem).to(
+        receive(:release_date)
+          .with('pg', ::Gem::Version.new('1.5.0'))
+          .and_return(::Date.new(2023, 4, 24))
+      )
+      allow(Models::Gem).to(
+        receive(:release_date)
+          .with('pg', ::Gem::Version.new('1.5.6'))
+          .and_return(::Date.new(2024, 3, 1))
+      )
+
+      Models::Gem.new('pg', '1.5.0', '1.5.6', nil)
+    end
+
+    def stub_rails_gem
+      allow(Models::Gem).to(
+        receive(:release_date)
+          .with('rails', ::Gem::Version.new('7.0.0'))
+          .and_return(::Date.new(2021, 12, 15))
+      )
+      allow(Models::Gem).to(
+        receive(:release_date)
+          .with('rails', ::Gem::Version.new('7.1.3'))
+          .and_return(::Date.new(2024, 1, 16))
+      )
+
+      Models::Gem.new('rails', '7.0.0', '7.1.3', nil)
     end
   end
 end


### PR DESCRIPTION
Closes #38.

Now, if we run cli with `--sort` option, it will sort by libyears/releases etc in descending order.