### PR TITLE
Correctly calculate libyears for the Ruby version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ Added:
 
 Fixed:
 
-- None
+- [#43](https://github.com/jaredbeck/libyear-bundler/pull/43) -
+  Fixed libyears calculation for Ruby version
 
 ## 0.8.0 (2024-09-13)
 

--- a/lib/libyear_bundler/models/ruby.rb
+++ b/lib/libyear_bundler/models/ruby.rb
@@ -62,7 +62,7 @@ module LibyearBundler
 
           # YAML#safe_load provides an already-parsed Date object, so the following
           # is a Date object
-          v['date']
+          @_version_data[v]['date']
         end
 
         private
@@ -84,7 +84,9 @@ module LibyearBundler
               con.request_get(uri.path)
             end
             if response.is_a?(::Net::HTTPSuccess)
-              YAMLLoader.safe_load(response.body).map { |release| release['version'] }
+              @_version_data = YAMLLoader.safe_load(response.body)
+                .map { |release| [release['version'], release] }.to_h
+              @_version_data.keys
             else
               warn format('Unable to get Ruby version list: response code: %s', response.code)
               []

--- a/spec/fixtures/vcr_cassettes/ruby_releases.yml
+++ b/spec/fixtures/vcr_cassettes/ruby_releases.yml
@@ -122,7 +122,7 @@ http_interactions:
         # 3.1 series
 
         - version: 3.1.2
-          date: '2022-04-12'
+          date: 2022-04-12
           post: "/en/news/2022/04/12/ruby-3-1-2-released/"
           url:
             gz: https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.2.tar.gz

--- a/spec/models/ruby_spec.rb
+++ b/spec/models/ruby_spec.rb
@@ -82,18 +82,12 @@ module LibyearBundler
 
       describe '#libyears' do
         it 'returns the number of years out-of-date' do
-          installed_version_release_date = Date.new(2017, 1, 1)
-          newest_version_release_date = Date.new(2018, 1, 1)
           ruby = described_class.new(nil, nil)
-          allow(described_class)
-            .to receive(:release_date)
-            .and_return(
-              installed_version_release_date,
-              newest_version_release_date
-            )
-          allow(ruby).to receive(:installed_version).and_return('9.9.9')
+          allow(described_class).to receive(:release_date).and_call_original
+          allow(ruby).to receive(:installed_version).and_return(::Gem::Version.new('3.1.0'))
+          allow(ruby).to receive(:newest_version).and_return(::Gem::Version.new('3.1.2'))
           VCR.use_cassette("ruby_releases") do
-            expect(ruby.libyears).to eq(1)
+            expect(ruby.libyears).to be_within(0.1).of(0.3)
           end
           expect(described_class).to have_received(:release_date).twice
         end


### PR DESCRIPTION
Currently, Ruby version always have `nil` date. This is due to the versions loaded being an array of strings, and then calling `v['date']` on a string has a very different meaning than a lookup in a Hash.

This MR saves the original Ruby releases response, indexed by version, in a `@_version_data` variable, and then later uses it to lookup the version.

**Before:**

```
$ bin/run --all gemfiles/ruby-3.3.rb
                       rubocop         0.56.0     2018-05-14         1.73.2     2025-03-04       195      [1, 0, 0]       6.8
         unicode-display_width          1.8.0     2021-09-15          3.1.4     2025-01-13        19      [2, 0, 0]       3.3
                          ruby          3.3.5                         3.4.2                        5      [0, 1, 0]       0.0
System is 10.1 libyears behind
Total releases behind: 219
Major, minor, patch versions behind: 3, 1, 0
```

**After:**

```
$ bin/run --all gemfiles/ruby-3.3.rb
                       rubocop         0.56.0     2018-05-14         1.73.2     2025-03-04       195      [1, 0, 0]       6.8
         unicode-display_width          1.8.0     2021-09-15          3.1.4     2025-01-13        19      [2, 0, 0]       3.3
                          ruby          3.3.5     2024-09-03          3.4.2     2025-02-14         5      [0, 1, 0]       0.4
System is 10.6 libyears behind
Total releases behind: 219
Major, minor, patch versions behind: 3, 1, 0
```