### PR TITLE
Added Ruby 3.4 and removed ostruct dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
           - '3.1'
           - '3.2'
           - '3.3'
+          - '3.4'
         include:
           # Ruby 2.2 does not currently work on ubuntu-latest:
           #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ Added:
 
 Fixed:
 
-- None
+- [#44](https://github.com/jaredbeck/libyear-bundler/pull/44) -
+  Fixed warnings about "ostruct" when running in Ruby 3.4
 
 ## 0.9.0 (2025-03-05)
 
@@ -47,7 +48,7 @@ Added:
 Fixed:
 
 - [#40](https://github.com/jaredbeck/libyear-bundler/pull/40) - Report
-problematic release dates only once per gem name
+  problematic release dates only once per gem name
 
 ## 0.7.0 (2024-05-11)
 

--- a/gemfiles/ruby-3.4.rb
+++ b/gemfiles/ruby-3.4.rb
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem "bundler", "~> 2.6"
+gem "rspec", "~> 3.12"
+gem "simplecov", "~> 0.22.0"
+gem "webmock", "~> 3.19"
+gem "vcr", "~> 6.2"

--- a/lib/libyear_bundler/options.rb
+++ b/lib/libyear_bundler/options.rb
@@ -1,7 +1,6 @@
 require 'optparse'
 require 'libyear_bundler/version'
 require "libyear_bundler/cli"
-require 'ostruct'
 
 module LibyearBundler
   # Uses OptionParser from Ruby's stdlib to hand command-line arguments
@@ -11,14 +10,18 @@ Usage: libyear-bundler [Gemfile ...] [options]
 https://github.com/jaredbeck/libyear-bundler/
     BANNER
 
+    Store = Struct.new(
+      :libyears?, :releases?, :versions?, :cache_path, :grand_total?, :sort?, :json?
+    )
+
     def initialize(argv)
       @argv = argv
-      @options = ::OpenStruct.new
+      @options = Store.new
       @optparser = OptionParser.new do |opts|
         opts.banner = BANNER
         opts.program_name = 'libyear-bundler'
         opts.version = ::LibyearBundler::VERSION
-        @options.send('libyears?=', true)
+        @options.send(:'libyears?=', true)
 
         opts.on_head('-h', '--help', 'Prints this help') do
           puts opts
@@ -26,9 +29,9 @@ https://github.com/jaredbeck/libyear-bundler/
         end
 
         opts.on('--all', 'Calculate all metrics') do
-          @options.send('libyears?=', true)
-          @options.send('releases?=', true)
-          @options.send('versions?=', true)
+          @options.send(:'libyears?=', true)
+          @options.send(:'releases?=', true)
+          @options.send(:'versions?=', true)
         end
 
         opts.on('--cache=CACHE_PATH', 'Use a cache across runs') do |cache_path|
@@ -36,29 +39,29 @@ https://github.com/jaredbeck/libyear-bundler/
         end
 
         opts.on('--libyears', '[default] Calculate libyears out-of-date') do
-          @options.send('libyears?=', true)
+          @options.send(:'libyears?=', true)
         end
 
         opts.on('--releases', 'Calculate number of releases out-of-date') do
-          @options.send('libyears?=', false)
-          @options.send('releases?=', true)
+          @options.send(:'libyears?=', false)
+          @options.send(:'releases?=', true)
         end
 
         opts.on('--versions', 'Calculate major, minor, and patch versions out-of-date') do
-          @options.send('libyears?=', false)
-          @options.send('versions?=', true)
+          @options.send(:'libyears?=', false)
+          @options.send(:'versions?=', true)
         end
 
         opts.on('--grand-total', 'Return value for given metric(s)') do
-          @options.send('grand_total?=', true)
+          @options.send(:'grand_total?=', true)
         end
 
         opts.on('--sort', 'Sort by selected metric(s), in descending order') do
-          @options.send('sort?=', true)
+          @options.send(:'sort?=', true)
         end
 
         opts.on('--json', 'Output JSON') do
-          @options.send('json?=', true)
+          @options.send(:'json?=', true)
         end
       end
     end


### PR DESCRIPTION
Starting with Ruby 3.4, requiring "ostruct" will trigger a warning:

```
<root>/lib/libyear_bundler/cli.rb:4: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
```

After Ruby 3.5.0 an explicit dependency on [ostruct](https://rubygems.org/gems/ostruct/) gem will be required, which does not add much value and is only used as an options store.