### PR TITLE
Fix ci build for ruby 2.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         run: bundle exec rubocop
   gha-job-pt-test:
     name: Ruby ${{ matrix.ruby }}
-    runs-on: ${{ matrix.os || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       # Currently a one-dimensional matrix of ruby versions. In the future we
@@ -42,17 +42,6 @@ jobs:
           - '3.2'
           - '3.3'
           - '3.4'
-        include:
-          # Ruby 2.2 does not currently work on ubuntu-latest:
-          #
-          # ```
-          # /opt/hostedtoolcache/Ruby/2.2.10/x64/bin/gem install bundler -v ~> 1.0
-          # ERROR:  While executing gem ... (RuntimeError)
-          # Marshal.load reentered at marshal_load
-          # Error: The process '/opt/hostedtoolcache/Ruby/2.2.10/x64/bin/gem' failed with exit code 1
-          # ```
-          - ruby: '2.2'
-            os: 'ubuntu-20.04'
     env:
       # > $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       # > https://github.com/ruby/setup-ruby#matrix-of-gemfiles
@@ -65,5 +54,29 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - name: Test
+        run: bundle exec rspec
+  gha-job-pt-container-test:
+    name: Ruby ${{ matrix.ruby }}
+    runs-on: ubuntu-latest
+    container:
+      image: ruby:${{ matrix.ruby }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - '2.2'
+    env:
+      # > $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
+      # > https://github.com/ruby/setup-ruby#matrix-of-gemfiles
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/ruby-${{ matrix.ruby }}.rb
+    steps:
+      - name: Checkout source
+        run: |
+          git init
+          git remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"
+          git fetch origin "$GITHUB_REF"
+          git checkout "$GITHUB_SHA"
+      - run: bundle install
       - name: Test
         run: bundle exec rspec


### PR DESCRIPTION
I happened to notice while working on a different pull request that the Ruby 2.2 job currently fails with this message:
```
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
```

Since no Actions runner seems to support Ruby 2.2 anymore I added a separate job that will run configured versions of Ruby in the official docker containers.

Note that I'm deliberately not using the official `actions/checkout` action because it requires a recent version of Node, which doesn't exist on the Docker image. In theory, it might be possible to install it at the start of the job, but it's probably not worth it.