### PR TITLE
Fallback to v0.9.0 logic for private gems

### DIFF
--- a/lib/libyear_bundler/bundle_outdated.rb
+++ b/lib/libyear_bundler/bundle_outdated.rb
@@ -17,6 +17,7 @@ module LibyearBundler
     end
 
     def execute
+      specs = find_specs
       uri = URI('https://rubygems.org')
       Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
         bundle_outdated.lines.each_with_object([]) do |line, gems|
@@ -31,6 +32,7 @@ module LibyearBundler
             match['name'],
             match['installed'],
             match['newest'],
+            specs[match['name']],
             @release_date_cache,
             http
           )
@@ -57,6 +59,22 @@ module LibyearBundler
         Kernel.exit(CLI::E_BUNDLE_OUTDATED_FAILED)
       end
       stdout
+    end
+
+    def find_specs
+      specs = Hash.new(:other)
+      lockfile_parser = ::Bundler::LockfileParser.new(Bundler.default_lockfile.read)
+      lockfile_parser.specs.each do |spec|
+        specs[spec.name] = if spec.source.nil? || spec.source.remotes.nil?
+                             :other
+                           elsif spec.source.remotes.length == 1 &&
+                                 spec.source.remotes.first.hostname == "rubygems.org"
+                             :rubygems
+                           else
+                             :other
+                           end
+      end
+      specs
     end
 
     # We rely on Gem::Version to handle version strings. If the string is malformed (usually because

--- a/lib/libyear_bundler/bundle_outdated.rb
+++ b/lib/libyear_bundler/bundle_outdated.rb
@@ -65,7 +65,9 @@ module LibyearBundler
       specs = Hash.new(:other)
       lockfile_parser = ::Bundler::LockfileParser.new(Bundler.default_lockfile.read)
       lockfile_parser.specs.each do |spec|
-        specs[spec.name] = if spec.source.nil? || spec.source.remotes.nil?
+        specs[spec.name] = if spec.source.nil?
+                             :other
+                           elsif !spec.source.respond_to?(:remotes) || spec.source.remotes.nil?
                              :other
                            elsif spec.source.remotes.length == 1 &&
                                  spec.source.remotes.first.hostname == "rubygems.org"

--- a/lib/libyear_bundler/models/gem.rb
+++ b/lib/libyear_bundler/models/gem.rb
@@ -7,19 +7,32 @@ module LibyearBundler
     # Logic and information pertaining to the installed and newest versions of
     # a gem
     class Gem
-      def initialize(name, installed_version, newest_version, release_date_cache, http)
+      # rubocop:disable Metrics/ParameterLists
+      def initialize(name, installed_version, newest_version, source, release_date_cache, http)
         unless release_date_cache.nil? || release_date_cache.is_a?(ReleaseDateCache)
           raise TypeError, 'Invalid release_date_cache'
         end
         @name = name
         @installed_version = installed_version
         @newest_version = newest_version
+        @source = source
         @release_date_cache = release_date_cache
         @http = http
       end
+      # rubocop:enable Metrics/ParameterLists
 
       class << self
-        def release_date(gem_name, gem_version, http)
+        def release_date(gem_name, gem_version, source, http)
+          if source == :rubygems
+            release_date_from_rubygems(gem_name, gem_version, http)
+          else
+            release_date_from_other(gem_name, gem_version)
+          end
+        end
+
+        private
+
+        def release_date_from_rubygems(gem_name, gem_version, http)
           uri = URI.parse(
             "https://rubygems.org/api/v2/rubygems/#{gem_name}/versions/#{gem_version}.json"
           )
@@ -39,7 +52,29 @@ module LibyearBundler
           report_problem(gem_name, "Release date not found: #{gem_name}: #{e.inspect}")
         end
 
-        private
+        def release_date_from_other(gem_name, gem_version)
+          dep = nil
+          begin
+            dep = ::Bundler::Dependency.new(gem_name, gem_version)
+          rescue ::Gem::Requirement::BadRequirementError => e
+            report_problem(gem_name, <<-MSG)
+Could not find release date for: #{gem_name}
+#{e}
+Maybe you used git in your Gemfile, which libyear doesn't support yet. Contributions welcome.
+            MSG
+            return nil
+          end
+          tuples, _errors = ::Gem::SpecFetcher.fetcher.search_for_dependency(dep)
+          if tuples.empty?
+            report_problem(gem_name, "Could not find release date for: #{gem_name}")
+            return nil
+          end
+          tup, source = tuples.first # Gem::NameTuple
+          spec = source.fetch_spec(tup) # raises Gem::RemoteFetcher::FetchError
+          spec.date.to_date
+        rescue StandardError => e
+          report_problem(gem_name, "Release date not found: #{gem_name}: #{e.inspect}")
+        end
 
         def report_problem(gem_name, message)
           @reported_gems ||= {}
@@ -56,7 +91,7 @@ module LibyearBundler
 
       def installed_version_release_date
         if @release_date_cache.nil?
-          self.class.release_date(name, installed_version, @http)
+          self.class.release_date(name, installed_version, @source, @http)
         else
           @release_date_cache[name, installed_version]
         end
@@ -87,7 +122,7 @@ module LibyearBundler
 
       def newest_version_release_date
         if @release_date_cache.nil?
-          self.class.release_date(name, newest_version, @http)
+          self.class.release_date(name, newest_version, @source, @http)
         else
           @release_date_cache[name, newest_version]
         end

--- a/spec/models/gem_spec.rb
+++ b/spec/models/gem_spec.rb
@@ -6,7 +6,7 @@ module LibyearBundler
       describe '#installed_version' do
         it 'returns the installed version' do
           newest_version = '1.0.0'
-          gem = described_class.new(nil, newest_version, nil, nil, nil)
+          gem = described_class.new(nil, newest_version, nil, :rubygems, nil, nil)
           expect(gem.installed_version).to eq(::Gem::Version.new(newest_version))
         end
       end
@@ -14,7 +14,7 @@ module LibyearBundler
       describe '#installed_version_release_date' do
         it 'returns the release date of the installed version' do
           date = Date.new(2017, 1, 1)
-          gem = described_class.new(nil, '9.9.9', nil, nil, nil)
+          gem = described_class.new(nil, '9.9.9', nil, :rubygems, nil, nil)
           allow(described_class).to receive(:release_date).and_return(date)
           expect(gem.installed_version_release_date).to eq(date)
         end
@@ -24,7 +24,7 @@ module LibyearBundler
         it 'returns the index' do
           installed_version = '1.0.0'
           newest_version = '2.0.0'
-          gem = described_class.new(nil, installed_version, newest_version, nil, nil)
+          gem = described_class.new(nil, installed_version, newest_version, :rubygems, nil, nil)
           allow(gem)
             .to receive(:versions_sequence)
             .and_return([newest_version, installed_version])
@@ -37,7 +37,7 @@ module LibyearBundler
           allow(::LibyearBundler::Calculators::Libyear)
             .to receive(:calculate)
             .and_return(1)
-          gem = described_class.new(nil, nil, nil, nil, nil)
+          gem = described_class.new(nil, nil, nil, :rubygems, nil, nil)
           allow(gem).to receive(:libyears).and_return(1)
         end
       end
@@ -45,7 +45,7 @@ module LibyearBundler
       describe '#name' do
         it 'returns the gem name' do
           gem_name = 'gem_name'
-          gem = described_class.new(gem_name, nil, nil, nil, nil)
+          gem = described_class.new(gem_name, nil, nil, :rubygems, nil, nil)
           expect(gem.name).to eq(gem_name)
         end
       end
@@ -53,7 +53,7 @@ module LibyearBundler
       describe '#newest_version' do
         it 'returns the newest version' do
           newest_version = '2.0.0'
-          gem = described_class.new(nil, nil, newest_version, nil, nil)
+          gem = described_class.new(nil, nil, newest_version, :rubygems, nil, nil)
           expect(gem.newest_version).to eq(::Gem::Version.new(newest_version))
         end
       end
@@ -61,7 +61,7 @@ module LibyearBundler
       describe '#newest_version_release_date' do
         it 'returns the release date of the newest version' do
           date = Date.new(2017, 1, 1)
-          gem = described_class.new('example', '9.9.0', '9.9.1', nil, nil)
+          gem = described_class.new('example', '9.9.0', '9.9.1', :rubygems, nil, nil)
           allow(described_class).to receive(:release_date).and_return(date)
           result = gem.newest_version_release_date
           expect(described_class).to have_received(:release_date)
@@ -73,7 +73,7 @@ module LibyearBundler
             date = Date.new(2017, 1, 1)
             cache = ::LibyearBundler::ReleaseDateCache.new({})
             allow(cache).to receive(:[]).and_call_original
-            gem = described_class.new('example', '9.9.0', '9.9.1', cache, nil)
+            gem = described_class.new('example', '9.9.0', '9.9.1', :rubygems, cache, nil)
             allow(described_class).to receive(:release_date).and_return(date)
             result = gem.newest_version_release_date
             expect(described_class).to have_received(:release_date)
@@ -87,7 +87,7 @@ module LibyearBundler
         it 'returns the index' do
           installed_version = '1.0.0'
           newest_version = '2.0.0'
-          gem = described_class.new(nil, installed_version, newest_version, nil, nil)
+          gem = described_class.new(nil, installed_version, newest_version, :rubygems, nil, nil)
           allow(gem)
             .to receive(:versions_sequence)
             .and_return([newest_version, installed_version])
@@ -97,7 +97,7 @@ module LibyearBundler
 
       describe '#version_number_delta' do
         it 'returns an array of the major, minor, and patch versions out-of-date' do
-          gem = described_class.new(nil, '1.0.0', '2.0.0', nil, nil)
+          gem = described_class.new(nil, '1.0.0', '2.0.0', :rubygems, nil, nil)
           expect(gem.version_number_delta).to eq([1, 0, 0])
         end
       end
@@ -106,7 +106,7 @@ module LibyearBundler
         it 'returns the number of releases between versions' do
           installed_version = '1.0.0'
           newest_version = '2.0.0'
-          gem = described_class.new(nil, installed_version, newest_version, nil, nil)
+          gem = described_class.new(nil, installed_version, newest_version, :rubygems, nil, nil)
           allow(gem)
             .to receive(:versions_sequence)
             .and_return([newest_version, installed_version])

--- a/spec/reports/console_spec.rb
+++ b/spec/reports/console_spec.rb
@@ -57,31 +57,31 @@ System is 2.9 libyears behind
       def stub_pg_gem
         allow(Models::Gem).to(
           receive(:release_date)
-            .with('pg', ::Gem::Version.new('1.5.0'), nil)
+            .with('pg', ::Gem::Version.new('1.5.0'), :rubygems, nil)
             .and_return(::Date.new(2023, 4, 24))
         )
         allow(Models::Gem).to(
           receive(:release_date)
-            .with('pg', ::Gem::Version.new('1.5.6'), nil)
+            .with('pg', ::Gem::Version.new('1.5.6'), :rubygems, nil)
             .and_return(::Date.new(2024, 3, 1))
         )
 
-        Models::Gem.new('pg', '1.5.0', '1.5.6', nil, nil)
+        Models::Gem.new('pg', '1.5.0', '1.5.6', :rubygems, nil, nil)
       end
 
       def stub_rails_gem
         allow(Models::Gem).to(
           receive(:release_date)
-            .with('rails', ::Gem::Version.new('7.0.0'), nil)
+            .with('rails', ::Gem::Version.new('7.0.0'), :rubygems, nil)
             .and_return(::Date.new(2021, 12, 15))
         )
         allow(Models::Gem).to(
           receive(:release_date)
-            .with('rails', ::Gem::Version.new('7.1.3'), nil)
+            .with('rails', ::Gem::Version.new('7.1.3'), :rubygems, nil)
             .and_return(::Date.new(2024, 1, 16))
         )
 
-        Models::Gem.new('rails', '7.0.0', '7.1.3', nil, nil)
+        Models::Gem.new('rails', '7.0.0', '7.1.3', :rubygems, nil, nil)
       end
     end
   end

--- a/spec/reports/json_spec.rb
+++ b/spec/reports/json_spec.rb
@@ -107,31 +107,31 @@ module LibyearBundler
       def stub_pg_gem
         allow(Models::Gem).to(
           receive(:release_date)
-            .with('pg', ::Gem::Version.new('1.5.0'), nil)
+            .with('pg', ::Gem::Version.new('1.5.0'), :rubygems, nil)
             .and_return(::Date.new(2023, 4, 24))
         )
         allow(Models::Gem).to(
           receive(:release_date)
-            .with('pg', ::Gem::Version.new('1.5.6'), nil)
+            .with('pg', ::Gem::Version.new('1.5.6'), :rubygems, nil)
             .and_return(::Date.new(2024, 3, 1))
         )
 
-        Models::Gem.new('pg', '1.5.0', '1.5.6', nil, nil)
+        Models::Gem.new('pg', '1.5.0', '1.5.6', :rubygems, nil, nil)
       end
 
       def stub_rails_gem
         allow(Models::Gem).to(
           receive(:release_date)
-            .with('rails', ::Gem::Version.new('7.0.0'), nil)
+            .with('rails', ::Gem::Version.new('7.0.0'), :rubygems, nil)
             .and_return(::Date.new(2021, 12, 15))
         )
         allow(Models::Gem).to(
           receive(:release_date)
-            .with('rails', ::Gem::Version.new('7.1.3'), nil)
+            .with('rails', ::Gem::Version.new('7.1.3'), :rubygems, nil)
             .and_return(::Date.new(2024, 1, 16))
         )
 
-        Models::Gem.new('rails', '7.0.0', '7.1.3', nil, nil)
+        Models::Gem.new('rails', '7.0.0', '7.1.3', :rubygems, nil, nil)
       end
     end
   end


### PR DESCRIPTION
Since v0.9.0, the code has been optimized to fetch the release date directly from the rubygems.org API. Unfortunately this meant that the release date could no longer be found for gems hosted on private servers.

In this commit, a `source` attribute is added to the `Gem` model. Possible values are `:rubygems` and `:other`. The value is decided by using `::Bundler::LockfileParser` to parse the lockfile and get the necessary information about each outdated gem.

The `.release_date` method now decides, based on the value of `source`, whether to call the current implementation, moved into `.release_date_from_rubygems`, or the implementation from v0.9.0, which now exists in `.release_date_from_other`.

I have added no tests (yet), but the code seems to work for the projects I usually use libyear-bundler on.

Fixes #51.