### PR TITLE
Added Ruby 4.0 to the build matrix, allow Bundler 4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
           - '3.2'
           - '3.3'
           - '3.4'
+          - '4.0'
     env:
       # > $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       # > https://github.com/ruby/setup-ruby#matrix-of-gemfiles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ Added:
 
 Fixed:
 
-- None
+- [#54](https://github.com/jaredbeck/libyear-bundler/pull/54) -
+  Added support for Bundler 4.x
 
 ## 0.9.1 (2025-10-09)
 

--- a/gemfiles/ruby-4.0.rb
+++ b/gemfiles/ruby-4.0.rb
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem "bundler", "~> 4.0"
+gem "rspec", "~> 3.12"
+gem "simplecov", "~> 0.22.0"
+gem "webmock", "~> 3.19"
+gem "vcr", "~> 6.2"

--- a/libyear-bundler.gemspec
+++ b/libyear-bundler.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   # We will support bundler 1 as long as we can. See `required_ruby_version`
   # above.
-  spec.add_dependency "bundler", ">= 1.14", "< 3"
+  spec.add_dependency "bundler", ">= 1.14", "< 5"
 
   # Development dependencies are specified in `/gemfiles`. See CONTRIBUTING.md
   # for details.


### PR DESCRIPTION
Ruby 4.0 was released with Bundler 4.0, making libyear-bundler incompatible due to strict bundler version check.

We currently only test against 2.x (3.x does not exist), and now 4.x in Ruby 4.0.
