### PR TITLE
Add support for multiple gem sources

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -24,6 +24,12 @@ Metrics/BlockLength:
 Metrics/ClassLength:
   Max: 119
 
+# Offense count: 1
+# Configuration parameters: CountKeywordArgs.
+Metrics/ParameterLists:
+  Exclude:
+    - 'lib/libyear_bundler/models/gem.rb'
+
 # Offense count: 5
 Naming/MemoizedInstanceVariableName:
   Exclude:

--- a/lib/libyear_bundler/bundle_outdated.rb
+++ b/lib/libyear_bundler/bundle_outdated.rb
@@ -1,5 +1,6 @@
 require "English"
 require "open3"
+require 'bundler'
 require 'libyear_bundler/calculators/libyear'
 require 'libyear_bundler/calculators/version_number_delta'
 require 'libyear_bundler/calculators/version_sequence_delta'
@@ -17,6 +18,7 @@ module LibyearBundler
     end
 
     def execute
+      gem_sources = load_gem_sources
       uri = URI('https://rubygems.org')
       Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
         bundle_outdated.lines.each_with_object([]) do |line, gems|
@@ -32,7 +34,8 @@ module LibyearBundler
             match['installed'],
             match['newest'],
             @release_date_cache,
-            http
+            http,
+            source: gem_sources[match['name']] || 'https://rubygems.org/'
           )
           gems.push(gem)
         end
@@ -40,6 +43,22 @@ module LibyearBundler
     end
 
     private
+
+    def load_gem_sources
+      lockfile_path = @gemfile_path.sub(/Gemfile$/, 'Gemfile.lock')
+      return {} unless File.exist?(lockfile_path)
+
+      lockfile_contents = File.read(lockfile_path)
+      lockfile = Bundler::LockfileParser.new(lockfile_contents)
+
+      lockfile.specs.each_with_object({}) do |spec, hash|
+        if spec.source.respond_to?(:remotes)
+          hash[spec.name] = spec.source.remotes.first.to_s
+        end
+      end
+    rescue StandardError
+      {}
+    end
 
     def bundle_outdated
       stdout, stderr, status = Open3.capture3(

--- a/lib/libyear_bundler/models/gem.rb
+++ b/lib/libyear_bundler/models/gem.rb
@@ -1,3 +1,4 @@
+require 'English'
 require 'net/http'
 require 'uri'
 require 'json'
@@ -7,7 +8,7 @@ module LibyearBundler
     # Logic and information pertaining to the installed and newest versions of
     # a gem
     class Gem
-      def initialize(name, installed_version, newest_version, release_date_cache, http)
+      def initialize(name, installed_version, newest_version, release_date_cache, http, source: 'https://rubygems.org/')
         unless release_date_cache.nil? || release_date_cache.is_a?(ReleaseDateCache)
           raise TypeError, 'Invalid release_date_cache'
         end
@@ -16,10 +17,28 @@ module LibyearBundler
         @newest_version = newest_version
         @release_date_cache = release_date_cache
         @http = http
+        @source = source
       end
 
       class << self
-        def release_date(gem_name, gem_version, http)
+        def release_date(gem_name, gem_version, http, source = 'https://rubygems.org/')
+          if source.include?('rubygems.pkg.github.com')
+            release_date_github_packages(gem_name, gem_version, source)
+          elsif source == 'https://rubygems.org/'
+            release_date_rubygems(gem_name, gem_version, http)
+          else
+            report_problem(gem_name, "Skipped: #{gem_name} (unsupported source: #{source})")
+            nil
+          end
+        end
+
+        def gh_available?
+          system('which gh > /dev/null 2>&1')
+        end
+
+        private
+
+        def release_date_rubygems(gem_name, gem_version, http)
           uri = URI.parse(
             "https://rubygems.org/api/v2/rubygems/#{gem_name}/versions/#{gem_version}.json"
           )
@@ -39,7 +58,30 @@ module LibyearBundler
           report_problem(gem_name, "Release date not found: #{gem_name}: #{e.inspect}")
         end
 
-        private
+        def release_date_github_packages(gem_name, gem_version, source)
+          unless gh_available?
+            report_problem(gem_name, "Skipped: #{gem_name} (private source, gh CLI not available)")
+            return nil
+          end
+
+          org = source.split('/').last.delete('/')
+          output, success = gh_api_call("/orgs/#{org}/packages/rubygems/#{gem_name}/versions")
+          return nil unless success
+
+          versions = JSON.parse(output)
+          version_data = versions.find { |v| v['name'] == gem_version.to_s }
+          return nil unless version_data
+
+          Date.parse(version_data['created_at'])
+        rescue StandardError => e
+          report_problem(gem_name, "Release date not found: #{gem_name}: #{e.inspect}")
+          nil
+        end
+
+        def gh_api_call(endpoint)
+          output = `gh api #{endpoint} 2>&1`
+          [output, $CHILD_STATUS.success?]
+        end
 
         def report_problem(gem_name, message)
           @reported_gems ||= {}
@@ -56,7 +98,7 @@ module LibyearBundler
 
       def installed_version_release_date
         if @release_date_cache.nil?
-          self.class.release_date(name, installed_version, @http)
+          self.class.release_date(name, installed_version, @http, @source)
         else
           @release_date_cache[name, installed_version]
         end
@@ -87,7 +129,7 @@ module LibyearBundler
 
       def newest_version_release_date
         if @release_date_cache.nil?
-          self.class.release_date(name, newest_version, @http)
+          self.class.release_date(name, newest_version, @http, @source)
         else
           @release_date_cache[name, newest_version]
         end

--- a/spec/fixtures/github_packages/Gemfile.lock
+++ b/spec/fixtures/github_packages/Gemfile.lock
@@ -1,0 +1,21 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    json (2.1.0)
+
+GEM
+  remote: https://rubygems.pkg.github.com/secret_org/
+  specs:
+    private_gem1 (2.6.0)
+    private_gem2 (5.5.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  private_gem1 (~> 2.6)
+  private_gem2 (~> 5.2)
+  json (= 2.1.0)
+
+BUNDLED WITH
+   2.5.0

--- a/spec/models/gem_source_spec.rb
+++ b/spec/models/gem_source_spec.rb
@@ -1,0 +1,100 @@
+require 'spec_helper'
+
+module LibyearBundler
+  module Models
+    RSpec.describe Gem do
+      describe '.release_date' do
+        context 'with rubygems.org source' do
+          it 'queries rubygems.org API' do
+            http = instance_double(Net::HTTP)
+            response = instance_double(Net::HTTPSuccess)
+            allow(response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true)
+            allow(response).to receive(:body)
+              .and_return('{"version_created_at":"2017-01-01T00:00:00Z"}')
+            allow(http).to receive(:request).and_return(response)
+
+            result = described_class.release_date('json', '2.1.0', http, 'https://rubygems.org/')
+
+            expect(result).to eq(Date.parse('2017-01-01'))
+          end
+        end
+
+        context 'with GitHub Packages source' do
+          context 'when gh CLI is available' do
+            it 'queries GitHub API via gh CLI' do
+              http = instance_double(Net::HTTP)
+              allow(described_class).to receive(:gh_available?).and_return(true)
+              allow(described_class).to receive(:gh_api_call)
+                .with('/orgs/secret_org/packages/rubygems/private_gem1/versions')
+                .and_return(['[{"name":"2.6.0","created_at":"2025-11-18T22:27:39Z"}]', true])
+
+              result = described_class.release_date(
+                'private_gem1',
+                '2.6.0',
+                http,
+                'https://rubygems.pkg.github.com/secret_org/'
+              )
+
+              expect(result).to eq(Date.parse('2025-11-18'))
+            end
+          end
+
+          context 'when gh CLI is not available' do
+            it 'returns nil and does not query' do
+              http = instance_double(Net::HTTP)
+              allow(described_class).to receive(:gh_available?).and_return(false)
+              allow(described_class).to receive(:report_problem)
+
+              result = described_class.release_date(
+                'private_gem1',
+                '2.6.0',
+                http,
+                'https://rubygems.pkg.github.com/secret_org/'
+              )
+
+              expect(result).to be_nil
+              expect(described_class).to have_received(:report_problem)
+                .with('private_gem1', /skipped.*private source/i)
+            end
+          end
+        end
+
+        context 'with unknown source' do
+          it 'returns nil and reports skipped' do
+            http = instance_double(Net::HTTP)
+            allow(described_class).to receive(:report_problem)
+
+            result = described_class.release_date(
+              'private_gem',
+              '1.0.0',
+              http,
+              'https://custom.gem.server/'
+            )
+
+            expect(result).to be_nil
+            expect(described_class).to have_received(:report_problem)
+              .with('private_gem', /skipped.*unsupported source/i)
+          end
+        end
+      end
+
+      describe '.gh_available?' do
+        it 'returns true when gh command exists' do
+          allow(described_class).to receive(:system)
+            .with('which gh > /dev/null 2>&1')
+            .and_return(true)
+
+          expect(described_class.gh_available?).to be true
+        end
+
+        it 'returns false when gh command does not exist' do
+          allow(described_class).to receive(:system)
+            .with('which gh > /dev/null 2>&1')
+            .and_return(false)
+
+          expect(described_class.gh_available?).to be false
+        end
+      end
+    end
+  end
+end

--- a/spec/reports/console_spec.rb
+++ b/spec/reports/console_spec.rb
@@ -57,12 +57,12 @@ System is 2.9 libyears behind
       def stub_pg_gem
         allow(Models::Gem).to(
           receive(:release_date)
-            .with('pg', ::Gem::Version.new('1.5.0'), nil)
+            .with('pg', ::Gem::Version.new('1.5.0'), nil, 'https://rubygems.org/')
             .and_return(::Date.new(2023, 4, 24))
         )
         allow(Models::Gem).to(
           receive(:release_date)
-            .with('pg', ::Gem::Version.new('1.5.6'), nil)
+            .with('pg', ::Gem::Version.new('1.5.6'), nil, 'https://rubygems.org/')
             .and_return(::Date.new(2024, 3, 1))
         )
 
@@ -72,12 +72,12 @@ System is 2.9 libyears behind
       def stub_rails_gem
         allow(Models::Gem).to(
           receive(:release_date)
-            .with('rails', ::Gem::Version.new('7.0.0'), nil)
+            .with('rails', ::Gem::Version.new('7.0.0'), nil, 'https://rubygems.org/')
             .and_return(::Date.new(2021, 12, 15))
         )
         allow(Models::Gem).to(
           receive(:release_date)
-            .with('rails', ::Gem::Version.new('7.1.3'), nil)
+            .with('rails', ::Gem::Version.new('7.1.3'), nil, 'https://rubygems.org/')
             .and_return(::Date.new(2024, 1, 16))
         )
 

--- a/spec/reports/json_spec.rb
+++ b/spec/reports/json_spec.rb
@@ -107,12 +107,12 @@ module LibyearBundler
       def stub_pg_gem
         allow(Models::Gem).to(
           receive(:release_date)
-            .with('pg', ::Gem::Version.new('1.5.0'), nil)
+            .with('pg', ::Gem::Version.new('1.5.0'), nil, 'https://rubygems.org/')
             .and_return(::Date.new(2023, 4, 24))
         )
         allow(Models::Gem).to(
           receive(:release_date)
-            .with('pg', ::Gem::Version.new('1.5.6'), nil)
+            .with('pg', ::Gem::Version.new('1.5.6'), nil, 'https://rubygems.org/')
             .and_return(::Date.new(2024, 3, 1))
         )
 
@@ -122,12 +122,12 @@ module LibyearBundler
       def stub_rails_gem
         allow(Models::Gem).to(
           receive(:release_date)
-            .with('rails', ::Gem::Version.new('7.0.0'), nil)
+            .with('rails', ::Gem::Version.new('7.0.0'), nil, 'https://rubygems.org/')
             .and_return(::Date.new(2021, 12, 15))
         )
         allow(Models::Gem).to(
           receive(:release_date)
-            .with('rails', ::Gem::Version.new('7.1.3'), nil)
+            .with('rails', ::Gem::Version.new('7.1.3'), nil, 'https://rubygems.org/')
             .and_return(::Date.new(2024, 1, 16))
         )
 


### PR DESCRIPTION
## Summary

Adds support for gems from multiple sources (rubygems.org, GitHub Packages, etc.) instead of hardcoding rubygems.org for all gems.

## Problem

Currently, libyear-bundler queries rubygems.org for all gems, causing 404 errors when analyzing projects with gems from private registries or GitHub Packages:

```
Release date not found: private_gem1: rubygems.org responded with 404
Release date not found: private_gem2: rubygems.org responded with 404
```

## Solution

- Parses `Gemfile.lock` using `Bundler::LockfileParser` to detect each gem's source
- Routes to appropriate API based on source:
- `rubygems.org` → RubyGems.org API (existing behavior)
- `rubygems.pkg.github.com` → GitHub API via `gh` CLI (when available)
- Other sources → Skip with clear message
- No new runtime dependencies (leverages existing `bundler` dependency)
- Graceful fallback when `gh` CLI is not available

## Testing

- Added 6 new tests for source detection and GitHub Packages integration
- All 55 tests pass
- Verified with real-world project containing GitHub Packages gems

## Result

**Before:**
```
private_gem1  2.6.0                2.7.0               0.0
private_gem2  5.5.0                5.6.0               0.0
```

**After:**
```
private_gem1  2.6.0  2025-11-18    2.8.0  2026-02-05   0.2
private_gem2  5.5.0  2025-10-27    5.6.0  2025-12-15   0.1
```
